### PR TITLE
ケースを作成しました。

### DIFF
--- a/PD_Adapter_Case.scad
+++ b/PD_Adapter_Case.scad
@@ -1,0 +1,148 @@
+W = 42.545;
+D = 22;
+RESOLUTION = 30;
+
+
+%translate([W/2, 0, 4])
+    import("C:/Users/comet/Documents/PD_Adapter.stl");
+
+
+module RoundedCube(x, y, z, r) {
+    cube([x-r*2, y, z], center=true);
+    cube([x, y-r*2, z], center=true);
+    translate([x/2-r, y/2-r, 0])
+        cylinder(r=r, h=z, $fn=RESOLUTION, center=true);
+    translate([x/2-r, -(y/2-r), 0])
+        cylinder(r=r, h=z, $fn=RESOLUTION, center=true);
+    translate([-(x/2-r), y/2-r, 0])
+        cylinder(r=r, h=z, $fn=RESOLUTION, center=true);
+    translate([-(x/2-r), -(y/2-r), 0])
+        cylinder(r=r, h=z, $fn=RESOLUTION, center=true);
+}
+
+
+module Pipe(r_outer, r_inner, h) {
+    difference() {
+        cylinder(r=r_outer, h=h, $fn=RESOLUTION);
+        cylinder(r=r_inner, h=h, $fn=RESOLUTION);
+    }
+}
+
+
+module CaseLower() {
+    // chassis
+    w_outer = W + 3;
+    d_outer = D + 3 + 4;
+    h_outer = 6.5;
+    r_outer = 4;
+    
+    w_inner = W + 0.6;
+    d_inner = D + 3 + 0.6;
+    h_inner = h_outer - 2;
+    r_inner = 2;
+
+    difference () {
+        translate([-0.5, 0, h_outer/2-4])
+            RoundedCube(w_outer, d_outer, h_outer, r_outer);
+        translate([0, 0, h_inner/2-4+2])
+            RoundedCube(w_inner, d_inner, h_inner, r_inner);
+        // usb-c connector
+        translate([W/2+1, 0, h_outer/2-4+2])
+            cube([10, 10, 3], center=true);
+    }
+    translate([0, d_outer/2-2.5, h_inner/2-4+0.5])
+        cube([w_inner-r_outer*4, 2, h_inner], center=true);
+    translate([0, -(d_outer/2-2.5), h_inner/2-4+0.5])
+        cube([w_inner-r_outer*4, 2, h_inner], center=true);
+    
+    // columns
+    w_holes = 36;
+    d_holes = 16;
+    r_c = 1.2;
+    h_c = 3;
+    translate([0, 0, -2]) {
+        translate([w_holes/2, d_holes/2, 0])
+            cylinder(r=r_c, h=h_c, $fn=RESOLUTION);
+        translate([w_holes/2, -d_holes/2, 0])
+            cylinder(r=r_c, h=h_c, $fn=RESOLUTION);
+        translate([-w_holes/2, d_holes/2, 0])
+            cylinder(r=r_c, h=h_c, $fn=RESOLUTION);
+        translate([-w_holes/2, -d_holes/2, 0])
+            cylinder(r=r_c, h=h_c, $fn=RESOLUTION);
+    }
+}
+
+
+module CaseUpper() {
+    w = W + 0.6;
+    d = D + 3 + 0.6;
+    h = 1.5;
+    r = 2;
+    
+    w_v = 33.6+0.6;
+    d_v = 6;
+
+    translate([0, 30, 1.5/2+1]) {
+        difference() {
+            RoundedCube(w, d, h, r);
+            
+            // usb-c connector
+            translate([(w-8)/2, 0, 0])
+                cube([8, 10, 3], center=true);
+            
+            // center void
+            translate([-(w-w_v)/2, 0, 0])
+                cube([w_v, d_v, 3], center=true);
+            
+        }
+        
+        // shroud
+        difference() {
+            hull() {
+                translate([-(w-w_v)/2, 0, 0])
+                    cube([w_v+2, d_v+6, 1.5], center=true);
+                
+                translate([-(w-w_v)/2, 0, 8-1/2])
+                    cube([w_v+2, d_v+2, 1], center=true);
+            }
+            
+            hull() {
+                translate([-(w-w_v-1)/2, 0, 0])
+                    cube([w_v-1, d_v, 1.5], center=true);
+                
+                translate([-(w-w_v-1)/2, 0, 8-1/2-1])
+                    cube([w_v-1, d_v, 1], center=true);
+            }
+            translate([-w/2-1, -(d_v+6)/2, -2])
+                cube([1, d_v+6, 20]);
+            
+            // hole for outlet
+            translate([-w/2+1, -d_v/2, -2])
+                cube([5, d_v, 20]);
+        }
+        
+
+        // columns
+        w_holes = 36;
+        d_holes = 16;
+        r_c_o = 1.2 + 1.0;
+        r_c_i = 1;
+        h_c = 1;
+        translate([0, 0, -(1.5/2+1)]) {
+            translate([w_holes/2, d_holes/2, 0])
+                Pipe(r_outer=r_c_o, r_inner=r_c_i, h=h_c);
+            translate([w_holes/2, -d_holes/2, 0])
+                Pipe(r_outer=r_c_o, r_inner=r_c_i, h=h_c);
+            translate([-w_holes/2, d_holes/2, 0])
+                Pipe(r_outer=r_c_o, r_inner=r_c_i, h=h_c);
+            translate([-w_holes/2, -d_holes/2, 0])
+                Pipe(r_outer=r_c_o, r_inner=r_c_i, h=h_c);
+        }
+    }
+}
+
+translate([0, 0, 4])
+    CaseLower();
+
+//translate([0, -30, 4])
+    CaseUpper();

--- a/PD_Adapter_Case.stl
+++ b/PD_Adapter_Case.stl
@@ -1,0 +1,14198 @@
+solid OpenSCAD_Model
+  facet normal -1 0 0
+    outer loop
+      vertex -19.2725 -14.5 0
+      vertex -19.2725 -14.4781 6.5
+      vertex -19.2725 -14.4781 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -19.2725 -14.4781 6.5
+      vertex -19.2725 -14.5 0
+      vertex -19.2725 -14.5 6.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -19.2725 14.4781 0
+      vertex -19.2725 14.5 6.5
+      vertex -19.2725 14.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -19.2725 14.5 6.5
+      vertex -19.2725 14.4781 0
+      vertex -19.2725 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2725 14.5 6.5
+      vertex -19.2725 14.5 6.5
+      vertex 18.2725 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.1851 11.3316 6.5
+      vertex 21.5288 11.2158 6.5
+      vertex 21.5725 10.8 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.1905 11.9756 6.5
+      vertex 21.9267 12.1269 6.5
+      vertex 21.5086 12.8511 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.1851 11.3316 6.5
+      vertex 21.3996 11.6135 6.5
+      vertex 21.5288 11.2158 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.9267 12.1269 6.5
+      vertex 21.1905 11.9756 6.5
+      vertex 21.3996 11.6135 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5725 12.5321 6.5
+      vertex 21.5086 12.8511 6.5
+      vertex 20.949 13.4726 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5086 12.8511 6.5
+      vertex 20.9108 12.2863 6.5
+      vertex 21.1905 11.9756 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5086 12.8511 6.5
+      vertex 20.5725 12.5321 6.5
+      vertex 20.9108 12.2863 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1905 12.7021 6.5
+      vertex 20.949 13.4726 6.5
+      vertex 20.2725 13.9641 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.949 13.4726 6.5
+      vertex 20.1905 12.7021 6.5
+      vertex 20.5725 12.5321 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.2725 13.9641 6.5
+      vertex 19.7816 12.789 6.5
+      vertex 20.1905 12.7021 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.2725 13.9641 6.5
+      vertex 19.5725 12.8 6.5
+      vertex 19.7816 12.789 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5086 14.3042 6.5
+      vertex 19.5725 12.8 6.5
+      vertex 20.2725 13.9641 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6906 14.4781 6.5
+      vertex 19.5725 12.8 6.5
+      vertex 19.5086 14.3042 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.2725 14.4781 6.5
+      vertex 19.5725 12.8 6.5
+      vertex 18.6906 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.2725 14.4781 6.5
+      vertex 18.2725 14.4781 6.5
+      vertex -19.2725 14.5 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 12.8 6.5
+      vertex 18.2725 14.4781 6.5
+      vertex -19.2725 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2725 14.4781 6.5
+      vertex -19.5725 12.8 6.5
+      vertex 19.5725 12.8 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.6906 14.4781 6.5
+      vertex -19.5725 12.8 6.5
+      vertex -19.2725 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.7816 12.789 6.5
+      vertex -19.5725 12.8 6.5
+      vertex -19.6906 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 12.8 6.5
+      vertex -19.7816 12.789 6.5
+      vertex -19.5725 12.789 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.5086 14.3042 6.5
+      vertex -19.7816 12.789 6.5
+      vertex -19.6906 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.7816 12.789 6.5
+      vertex -20.5086 14.3042 6.5
+      vertex -20.1905 12.7021 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.2725 13.9641 6.5
+      vertex -20.1905 12.7021 6.5
+      vertex -20.5086 14.3042 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1905 12.7021 6.5
+      vertex -21.2725 13.9641 6.5
+      vertex -20.5725 12.5321 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.949 13.4726 6.5
+      vertex -20.5725 12.5321 6.5
+      vertex -21.2725 13.9641 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5725 12.5321 6.5
+      vertex -21.949 13.4726 6.5
+      vertex -20.9108 12.2863 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9108 12.2863 6.5
+      vertex -21.949 13.4726 6.5
+      vertex -21.1905 11.9756 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.5086 12.8511 6.5
+      vertex -21.1905 11.9756 6.5
+      vertex -21.949 13.4726 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1905 11.9756 6.5
+      vertex -22.5086 12.8511 6.5
+      vertex -21.3996 11.6135 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.3996 11.6135 6.5
+      vertex -22.9267 12.1269 6.5
+      vertex -21.5288 11.2158 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.9267 12.1269 6.5
+      vertex -21.3996 11.6135 6.5
+      vertex -22.5086 12.8511 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.5725 10.8 6.5
+      vertex 22.2725 10.5 6.5
+      vertex 22.1851 11.3316 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.3996 11.6135 6.5
+      vertex 22.1851 11.3316 6.5
+      vertex 21.9267 12.1269 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5725 5 6.5
+      vertex 22.2725 10.5 6.5
+      vertex 21.5725 10.8 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2725 10.5 6.5
+      vertex 21.5725 5 6.5
+      vertex 22.2725 5 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.7816 12.789 6.5
+      vertex 19.5725 12.8 6.5
+      vertex 19.5725 12.789 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.7816 -12.789 6.5
+      vertex -19.5725 -12.8 6.5
+      vertex -19.5725 -12.789 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.8 6.5
+      vertex -19.7816 -12.789 6.5
+      vertex -19.6906 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5086 -14.3042 6.5
+      vertex -19.7816 -12.789 6.5
+      vertex -20.1905 -12.7021 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.7816 -12.789 6.5
+      vertex -20.5086 -14.3042 6.5
+      vertex -19.6906 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.2725 -13.9641 6.5
+      vertex -20.1905 -12.7021 6.5
+      vertex -20.5725 -12.5321 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.949 -13.4726 6.5
+      vertex -20.5725 -12.5321 6.5
+      vertex -20.9108 -12.2863 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.949 -13.4726 6.5
+      vertex -20.9108 -12.2863 6.5
+      vertex -21.1905 -11.9756 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1905 -12.7021 6.5
+      vertex -21.2725 -13.9641 6.5
+      vertex -20.5086 -14.3042 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5086 -12.8511 6.5
+      vertex -21.1905 -11.9756 6.5
+      vertex -21.3996 -11.6135 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.9267 -12.1269 6.5
+      vertex -21.3996 -11.6135 6.5
+      vertex -21.5288 -11.2158 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1851 -11.3316 6.5
+      vertex -21.5288 -11.2158 6.5
+      vertex -21.5725 -10.8 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5725 -12.5321 6.5
+      vertex -21.949 -13.4726 6.5
+      vertex -21.2725 -13.9641 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 6.5
+      vertex -23.2725 10.5 6.5
+      vertex -21.5725 -10.8 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.1851 11.3316 6.5
+      vertex -21.5288 11.2158 6.5
+      vertex -22.9267 12.1269 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.2725 -10.5 6.5
+      vertex -21.5725 -10.8 6.5
+      vertex -23.2725 10.5 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5288 11.2158 6.5
+      vertex -23.1851 11.3316 6.5
+      vertex -21.5725 10.8 6.5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -23.1851 -11.3316 6.5
+      vertex -21.5725 -10.8 6.5
+      vertex -23.2725 -10.5 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 6.5
+      vertex -23.1851 11.3316 6.5
+      vertex -23.2725 10.5 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1905 -11.9756 6.5
+      vertex -22.5086 -12.8511 6.5
+      vertex -21.949 -13.4726 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.3996 -11.6135 6.5
+      vertex -22.9267 -12.1269 6.5
+      vertex -22.5086 -12.8511 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5288 -11.2158 6.5
+      vertex -23.1851 -11.3316 6.5
+      vertex -22.9267 -12.1269 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.5725 -5 6.5
+      vertex 22.2725 -10.5 6.5
+      vertex 22.2725 -5 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2725 -10.5 6.5
+      vertex 21.5725 -10.8 6.5
+      vertex 22.1851 -11.3316 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2725 -10.5 6.5
+      vertex 21.5725 -5 6.5
+      vertex 21.5725 -10.8 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.5288 -11.2158 6.5
+      vertex 22.1851 -11.3316 6.5
+      vertex 21.5725 -10.8 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.3996 -11.6135 6.5
+      vertex 22.1851 -11.3316 6.5
+      vertex 21.5288 -11.2158 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.1851 -11.3316 6.5
+      vertex 21.3996 -11.6135 6.5
+      vertex 21.9267 -12.1269 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.1905 -11.9756 6.5
+      vertex 21.9267 -12.1269 6.5
+      vertex 21.3996 -11.6135 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.9267 -12.1269 6.5
+      vertex 21.1905 -11.9756 6.5
+      vertex 21.5086 -12.8511 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.9108 -12.2863 6.5
+      vertex 21.5086 -12.8511 6.5
+      vertex 21.1905 -11.9756 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.5725 -12.5321 6.5
+      vertex 21.5086 -12.8511 6.5
+      vertex 20.9108 -12.2863 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5086 -12.8511 6.5
+      vertex 20.5725 -12.5321 6.5
+      vertex 20.949 -13.4726 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.1905 -12.7021 6.5
+      vertex 20.949 -13.4726 6.5
+      vertex 20.5725 -12.5321 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.949 -13.4726 6.5
+      vertex 20.1905 -12.7021 6.5
+      vertex 20.2725 -13.9641 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.7816 -12.789 6.5
+      vertex 20.2725 -13.9641 6.5
+      vertex 20.1905 -12.7021 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 -12.8 6.5
+      vertex 19.7816 -12.789 6.5
+      vertex 19.5725 -12.789 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.7816 -12.789 6.5
+      vertex 19.5725 -12.8 6.5
+      vertex 20.2725 -13.9641 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 -12.8 6.5
+      vertex 19.5086 -14.3042 6.5
+      vertex 20.2725 -13.9641 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 -12.8 6.5
+      vertex 18.6906 -14.4781 6.5
+      vertex 19.5086 -14.3042 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 -12.8 6.5
+      vertex 18.2725 -14.4781 6.5
+      vertex 18.6906 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2725 -14.4781 6.5
+      vertex -19.2725 -14.4781 6.5
+      vertex 18.2725 -14.5 6.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.5725 -12.8 6.5
+      vertex 18.2725 -14.4781 6.5
+      vertex 19.5725 -12.8 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2725 -14.4781 6.5
+      vertex -19.5725 -12.8 6.5
+      vertex -19.2725 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.2725 -14.4781 6.5
+      vertex -19.5725 -12.8 6.5
+      vertex -19.6906 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2725 -14.5 6.5
+      vertex -19.2725 -14.4781 6.5
+      vertex -19.2725 -14.5 6.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 18.2725 -14.5 6.5
+      vertex 18.2725 -14.4781 0
+      vertex 18.2725 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 18.2725 -14.5 6.5
+      vertex 18.2725 -14.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 18.2725 14.4781 6.5
+      vertex 18.2725 14.5 0
+      vertex 18.2725 14.5 6.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 18.2725 14.5 0
+      vertex 18.2725 14.4781 6.5
+      vertex 18.2725 14.4781 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.2725 14.5 0
+      vertex -19.2725 14.5 6.5
+      vertex 18.2725 14.5 6.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -19.2725 14.5 6.5
+      vertex 18.2725 14.5 0
+      vertex -19.2725 14.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5086 -14.3042 0
+      vertex -19.2725 -14.4781 0
+      vertex -19.6906 -14.4781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.2725 -14.4781 0
+      vertex -23.2725 -10.5 0
+      vertex -19.2725 14.4781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.2725 -13.9641 0
+      vertex -19.2725 -14.4781 0
+      vertex -20.5086 -14.3042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2725 10.5 0
+      vertex -19.2725 14.4781 0
+      vertex -23.2725 -10.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.2725 -14.4781 0
+      vertex -21.2725 -13.9641 0
+      vertex -23.2725 -10.5 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -21.2725 13.9641 0
+      vertex -19.2725 14.4781 0
+      vertex -23.2725 10.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2725 -10.5 0
+      vertex -21.2725 -13.9641 0
+      vertex -21.949 -13.4726 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.2725 14.4781 0
+      vertex -20.5086 14.3042 0
+      vertex -19.6906 14.4781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2725 -10.5 0
+      vertex -21.949 -13.4726 0
+      vertex -22.5086 -12.8511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.2725 14.4781 0
+      vertex -21.2725 13.9641 0
+      vertex -20.5086 14.3042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2725 -10.5 0
+      vertex -22.5086 -12.8511 0
+      vertex -22.9267 -12.1269 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.2725 13.9641 0
+      vertex -23.2725 10.5 0
+      vertex -21.949 13.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2725 -10.5 0
+      vertex -22.9267 -12.1269 0
+      vertex -23.1851 -11.3316 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.949 13.4726 0
+      vertex -23.2725 10.5 0
+      vertex -22.5086 12.8511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5086 12.8511 0
+      vertex -23.2725 10.5 0
+      vertex -22.9267 12.1269 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.9267 12.1269 0
+      vertex -23.2725 10.5 0
+      vertex -23.1851 11.3316 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.2725 -14.4781 0
+      vertex 18.2725 -14.4781 0
+      vertex 18.2725 -14.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex -19.2725 -14.4781 0
+      vertex 18.2725 14.4781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.2725 -14.4781 0
+      vertex 18.2725 -14.5 0
+      vertex -19.2725 -14.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.2725 14.4781 0
+      vertex 18.2725 14.4781 0
+      vertex -19.2725 -14.4781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 14.4781 0
+      vertex -19.2725 14.4781 0
+      vertex 18.2725 14.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.2725 14.5 0
+      vertex -19.2725 14.4781 0
+      vertex -19.2725 14.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 22.2725 -10.5 0
+      vertex 22.1851 -11.3316 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 22.2725 -10.5 0
+      vertex 18.2725 -14.4781 0
+      vertex 22.2725 10.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 22.1851 -11.3316 0
+      vertex 21.9267 -12.1269 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 14.4781 0
+      vertex 22.2725 10.5 0
+      vertex 18.2725 -14.4781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 21.9267 -12.1269 0
+      vertex 21.5086 -12.8511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.2725 10.5 0
+      vertex 18.2725 14.4781 0
+      vertex 22.1851 11.3316 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 21.5086 -12.8511 0
+      vertex 20.949 -13.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.1851 11.3316 0
+      vertex 18.2725 14.4781 0
+      vertex 21.9267 12.1269 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 20.949 -13.4726 0
+      vertex 20.2725 -13.9641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.9267 12.1269 0
+      vertex 18.2725 14.4781 0
+      vertex 21.5086 12.8511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 20.2725 -13.9641 0
+      vertex 19.5086 -14.3042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5086 12.8511 0
+      vertex 18.2725 14.4781 0
+      vertex 20.949 13.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 19.5086 -14.3042 0
+      vertex 18.6906 -14.4781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.949 13.4726 0
+      vertex 18.2725 14.4781 0
+      vertex 20.2725 13.9641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.2725 13.9641 0
+      vertex 18.2725 14.4781 0
+      vertex 19.5086 14.3042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5086 14.3042 0
+      vertex 18.2725 14.4781 0
+      vertex 18.6906 14.4781 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -19.2725 -14.5 0
+      vertex 18.2725 -14.5 6.5
+      vertex -19.2725 -14.5 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.2725 -14.5 6.5
+      vertex -19.2725 -14.5 0
+      vertex 18.2725 -14.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -23.2725 -10.5 0
+      vertex -23.2725 10.5 6.5
+      vertex -23.2725 10.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -23.2725 10.5 6.5
+      vertex -23.2725 -10.5 0
+      vertex -23.2725 -10.5 6.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 22.2725 -5 6.5
+      vertex 22.2725 -10.5 6.5
+      vertex 22.2725 -5 3.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 22.2725 5 3.75
+      vertex 22.2725 10.5 6.5
+      vertex 22.2725 5 6.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 22.2725 10.5 6.5
+      vertex 22.2725 5 3.75
+      vertex 22.2725 10.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 22.2725 -5 3.75
+      vertex 22.2725 10.5 0
+      vertex 22.2725 5 3.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 22.2725 -5 3.75
+      vertex 22.2725 -10.5 0
+      vertex 22.2725 10.5 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 22.2725 -10.5 0
+      vertex 22.2725 -5 3.75
+      vertex 22.2725 -10.5 6.5
+    endloop
+  endfacet
+  facet normal 0.866034 0.499985 0
+    outer loop
+      vertex 21.9267 12.1269 6.5
+      vertex 21.5086 12.8511 0
+      vertex 21.5086 12.8511 6.5
+    endloop
+  endfacet
+  facet normal 0.866034 0.499985 0
+    outer loop
+      vertex 21.5086 12.8511 0
+      vertex 21.9267 12.1269 6.5
+      vertex 21.9267 12.1269 0
+    endloop
+  endfacet
+  facet normal 0.743145 0.66913 0
+    outer loop
+      vertex 21.5086 12.8511 6.5
+      vertex 20.949 13.4726 0
+      vertex 20.949 13.4726 6.5
+    endloop
+  endfacet
+  facet normal 0.743145 0.66913 0
+    outer loop
+      vertex 20.949 13.4726 0
+      vertex 21.5086 12.8511 6.5
+      vertex 21.5086 12.8511 0
+    endloop
+  endfacet
+  facet normal 0.207945 0.978141 -0
+    outer loop
+      vertex 19.5086 14.3042 0
+      vertex 18.6906 14.4781 6.5
+      vertex 19.5086 14.3042 6.5
+    endloop
+  endfacet
+  facet normal 0.207945 0.978141 0
+    outer loop
+      vertex 18.6906 14.4781 6.5
+      vertex 19.5086 14.3042 0
+      vertex 18.6906 14.4781 0
+    endloop
+  endfacet
+  facet normal 0.406726 0.91355 -0
+    outer loop
+      vertex 20.2725 13.9641 0
+      vertex 19.5086 14.3042 6.5
+      vertex 20.2725 13.9641 6.5
+    endloop
+  endfacet
+  facet normal 0.406726 0.91355 0
+    outer loop
+      vertex 19.5086 14.3042 6.5
+      vertex 20.2725 13.9641 0
+      vertex 19.5086 14.3042 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.6906 14.4781 0
+      vertex 18.2725 14.4781 6.5
+      vertex 18.6906 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.2725 14.4781 6.5
+      vertex 18.6906 14.4781 0
+      vertex 18.2725 14.4781 0
+    endloop
+  endfacet
+  facet normal 0.587781 0.80902 -0
+    outer loop
+      vertex 20.949 13.4726 0
+      vertex 20.2725 13.9641 6.5
+      vertex 20.949 13.4726 6.5
+    endloop
+  endfacet
+  facet normal 0.587781 0.80902 0
+    outer loop
+      vertex 20.2725 13.9641 6.5
+      vertex 20.949 13.4726 0
+      vertex 20.2725 13.9641 0
+    endloop
+  endfacet
+  facet normal 0.994522 0.104523 0
+    outer loop
+      vertex 22.2725 10.5 6.5
+      vertex 22.1851 11.3316 0
+      vertex 22.1851 11.3316 6.5
+    endloop
+  endfacet
+  facet normal 0.994522 0.104523 0
+    outer loop
+      vertex 22.1851 11.3316 0
+      vertex 22.2725 10.5 6.5
+      vertex 22.2725 10.5 0
+    endloop
+  endfacet
+  facet normal 0.95106 0.309008 0
+    outer loop
+      vertex 22.1851 11.3316 6.5
+      vertex 21.9267 12.1269 0
+      vertex 21.9267 12.1269 6.5
+    endloop
+  endfacet
+  facet normal 0.95106 0.309008 0
+    outer loop
+      vertex 21.9267 12.1269 0
+      vertex 22.1851 11.3316 6.5
+      vertex 22.1851 11.3316 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 18.2725 -14.4781 0
+      vertex 18.6906 -14.4781 6.5
+      vertex 18.2725 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.6906 -14.4781 6.5
+      vertex 18.2725 -14.4781 0
+      vertex 18.6906 -14.4781 0
+    endloop
+  endfacet
+  facet normal 0.866034 -0.499985 0
+    outer loop
+      vertex 21.5086 -12.8511 6.5
+      vertex 21.9267 -12.1269 0
+      vertex 21.9267 -12.1269 6.5
+    endloop
+  endfacet
+  facet normal 0.866034 -0.499985 0
+    outer loop
+      vertex 21.9267 -12.1269 0
+      vertex 21.5086 -12.8511 6.5
+      vertex 21.5086 -12.8511 0
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104523 0
+    outer loop
+      vertex 22.1851 -11.3316 6.5
+      vertex 22.2725 -10.5 0
+      vertex 22.2725 -10.5 6.5
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104523 0
+    outer loop
+      vertex 22.2725 -10.5 0
+      vertex 22.1851 -11.3316 6.5
+      vertex 22.1851 -11.3316 0
+    endloop
+  endfacet
+  facet normal 0.207945 -0.978141 0
+    outer loop
+      vertex 18.6906 -14.4781 0
+      vertex 19.5086 -14.3042 6.5
+      vertex 18.6906 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0.207945 -0.978141 0
+    outer loop
+      vertex 19.5086 -14.3042 6.5
+      vertex 18.6906 -14.4781 0
+      vertex 19.5086 -14.3042 0
+    endloop
+  endfacet
+  facet normal 0.587781 -0.80902 0
+    outer loop
+      vertex 20.2725 -13.9641 0
+      vertex 20.949 -13.4726 6.5
+      vertex 20.2725 -13.9641 6.5
+    endloop
+  endfacet
+  facet normal 0.587781 -0.80902 0
+    outer loop
+      vertex 20.949 -13.4726 6.5
+      vertex 20.2725 -13.9641 0
+      vertex 20.949 -13.4726 0
+    endloop
+  endfacet
+  facet normal 0.743145 -0.66913 0
+    outer loop
+      vertex 20.949 -13.4726 6.5
+      vertex 21.5086 -12.8511 0
+      vertex 21.5086 -12.8511 6.5
+    endloop
+  endfacet
+  facet normal 0.743145 -0.66913 0
+    outer loop
+      vertex 21.5086 -12.8511 0
+      vertex 20.949 -13.4726 6.5
+      vertex 20.949 -13.4726 0
+    endloop
+  endfacet
+  facet normal 0.95106 -0.309008 0
+    outer loop
+      vertex 21.9267 -12.1269 6.5
+      vertex 22.1851 -11.3316 0
+      vertex 22.1851 -11.3316 6.5
+    endloop
+  endfacet
+  facet normal 0.95106 -0.309008 0
+    outer loop
+      vertex 22.1851 -11.3316 0
+      vertex 21.9267 -12.1269 6.5
+      vertex 21.9267 -12.1269 0
+    endloop
+  endfacet
+  facet normal 0.406726 -0.91355 0
+    outer loop
+      vertex 19.5086 -14.3042 0
+      vertex 20.2725 -13.9641 6.5
+      vertex 19.5086 -14.3042 6.5
+    endloop
+  endfacet
+  facet normal 0.406726 -0.91355 0
+    outer loop
+      vertex 20.2725 -13.9641 6.5
+      vertex 19.5086 -14.3042 0
+      vertex 20.2725 -13.9641 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -19.2725 14.4781 0
+      vertex -19.6906 14.4781 6.5
+      vertex -19.2725 14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -19.6906 14.4781 6.5
+      vertex -19.2725 14.4781 0
+      vertex -19.6906 14.4781 0
+    endloop
+  endfacet
+  facet normal -0.743145 0.66913 0
+    outer loop
+      vertex -22.5086 12.8511 0
+      vertex -21.949 13.4726 6.5
+      vertex -21.949 13.4726 0
+    endloop
+  endfacet
+  facet normal -0.743145 0.66913 0
+    outer loop
+      vertex -21.949 13.4726 6.5
+      vertex -22.5086 12.8511 0
+      vertex -22.5086 12.8511 6.5
+    endloop
+  endfacet
+  facet normal -0.406726 0.91355 0
+    outer loop
+      vertex -20.5086 14.3042 0
+      vertex -21.2725 13.9641 6.5
+      vertex -20.5086 14.3042 6.5
+    endloop
+  endfacet
+  facet normal -0.406726 0.91355 0
+    outer loop
+      vertex -21.2725 13.9641 6.5
+      vertex -20.5086 14.3042 0
+      vertex -21.2725 13.9641 0
+    endloop
+  endfacet
+  facet normal -0.95106 0.309008 0
+    outer loop
+      vertex -23.1851 11.3316 0
+      vertex -22.9267 12.1269 6.5
+      vertex -22.9267 12.1269 0
+    endloop
+  endfacet
+  facet normal -0.95106 0.309008 0
+    outer loop
+      vertex -22.9267 12.1269 6.5
+      vertex -23.1851 11.3316 0
+      vertex -23.1851 11.3316 6.5
+    endloop
+  endfacet
+  facet normal -0.866034 0.499985 0
+    outer loop
+      vertex -22.9267 12.1269 0
+      vertex -22.5086 12.8511 6.5
+      vertex -22.5086 12.8511 0
+    endloop
+  endfacet
+  facet normal -0.866034 0.499985 0
+    outer loop
+      vertex -22.5086 12.8511 6.5
+      vertex -22.9267 12.1269 0
+      vertex -22.9267 12.1269 6.5
+    endloop
+  endfacet
+  facet normal -0.994522 0.104523 0
+    outer loop
+      vertex -23.2725 10.5 0
+      vertex -23.1851 11.3316 6.5
+      vertex -23.1851 11.3316 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104523 0
+    outer loop
+      vertex -23.1851 11.3316 6.5
+      vertex -23.2725 10.5 0
+      vertex -23.2725 10.5 6.5
+    endloop
+  endfacet
+  facet normal -0.587781 0.80902 0
+    outer loop
+      vertex -21.2725 13.9641 0
+      vertex -21.949 13.4726 6.5
+      vertex -21.2725 13.9641 6.5
+    endloop
+  endfacet
+  facet normal -0.587781 0.80902 0
+    outer loop
+      vertex -21.949 13.4726 6.5
+      vertex -21.2725 13.9641 0
+      vertex -21.949 13.4726 0
+    endloop
+  endfacet
+  facet normal -0.207945 0.978141 0
+    outer loop
+      vertex -19.6906 14.4781 0
+      vertex -20.5086 14.3042 6.5
+      vertex -19.6906 14.4781 6.5
+    endloop
+  endfacet
+  facet normal -0.207945 0.978141 0
+    outer loop
+      vertex -20.5086 14.3042 6.5
+      vertex -19.6906 14.4781 0
+      vertex -20.5086 14.3042 0
+    endloop
+  endfacet
+  facet normal -0.587781 -0.80902 0
+    outer loop
+      vertex -21.949 -13.4726 0
+      vertex -21.2725 -13.9641 6.5
+      vertex -21.949 -13.4726 6.5
+    endloop
+  endfacet
+  facet normal -0.587781 -0.80902 -0
+    outer loop
+      vertex -21.2725 -13.9641 6.5
+      vertex -21.949 -13.4726 0
+      vertex -21.2725 -13.9641 0
+    endloop
+  endfacet
+  facet normal -0.207945 -0.978141 0
+    outer loop
+      vertex -20.5086 -14.3042 0
+      vertex -19.6906 -14.4781 6.5
+      vertex -20.5086 -14.3042 6.5
+    endloop
+  endfacet
+  facet normal -0.207945 -0.978141 -0
+    outer loop
+      vertex -19.6906 -14.4781 6.5
+      vertex -20.5086 -14.3042 0
+      vertex -19.6906 -14.4781 0
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex -21.949 -13.4726 0
+      vertex -22.5086 -12.8511 6.5
+      vertex -22.5086 -12.8511 0
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex -22.5086 -12.8511 6.5
+      vertex -21.949 -13.4726 0
+      vertex -21.949 -13.4726 6.5
+    endloop
+  endfacet
+  facet normal -0.95106 -0.309008 0
+    outer loop
+      vertex -22.9267 -12.1269 0
+      vertex -23.1851 -11.3316 6.5
+      vertex -23.1851 -11.3316 0
+    endloop
+  endfacet
+  facet normal -0.95106 -0.309008 0
+    outer loop
+      vertex -23.1851 -11.3316 6.5
+      vertex -22.9267 -12.1269 0
+      vertex -22.9267 -12.1269 6.5
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104523 0
+    outer loop
+      vertex -23.1851 -11.3316 0
+      vertex -23.2725 -10.5 6.5
+      vertex -23.2725 -10.5 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104523 0
+    outer loop
+      vertex -23.2725 -10.5 6.5
+      vertex -23.1851 -11.3316 0
+      vertex -23.1851 -11.3316 6.5
+    endloop
+  endfacet
+  facet normal -0.406726 -0.91355 0
+    outer loop
+      vertex -21.2725 -13.9641 0
+      vertex -20.5086 -14.3042 6.5
+      vertex -21.2725 -13.9641 6.5
+    endloop
+  endfacet
+  facet normal -0.406726 -0.91355 -0
+    outer loop
+      vertex -20.5086 -14.3042 6.5
+      vertex -21.2725 -13.9641 0
+      vertex -20.5086 -14.3042 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -19.6906 -14.4781 0
+      vertex -19.2725 -14.4781 6.5
+      vertex -19.6906 -14.4781 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -19.2725 -14.4781 6.5
+      vertex -19.6906 -14.4781 0
+      vertex -19.2725 -14.4781 0
+    endloop
+  endfacet
+  facet normal -0.866034 -0.499985 0
+    outer loop
+      vertex -22.5086 -12.8511 0
+      vertex -22.9267 -12.1269 6.5
+      vertex -22.9267 -12.1269 0
+    endloop
+  endfacet
+  facet normal -0.866034 -0.499985 0
+    outer loop
+      vertex -22.9267 -12.1269 6.5
+      vertex -22.5086 -12.8511 0
+      vertex -22.5086 -12.8511 6.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -19.5725 -12.8 6.5
+      vertex -19.5725 -12.789 2
+      vertex -19.5725 -12.789 6.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -19.5725 -12.8 6.5
+      vertex -19.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -19.5725 12.789 6.5
+      vertex -19.5725 12.8 2
+      vertex -19.5725 12.8 6.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -19.5725 12.8 2
+      vertex -19.5725 12.789 6.5
+      vertex -19.5725 12.789 2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 19.5725 -12.8 2
+      vertex 19.5725 -12.789 6.5
+      vertex 19.5725 -12.789 2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 19.5725 -12.789 6.5
+      vertex 19.5725 -12.8 2
+      vertex 19.5725 -12.8 6.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 19.5725 12.8 6.5
+      vertex 19.5725 12.8 2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 19.5725 12.8 6.5
+      vertex 19.5725 12.789 2
+      vertex 19.5725 12.789 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -19.5725 12.8 6.5
+      vertex -13.5725 12.8 5
+      vertex 19.5725 12.8 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -19.5725 12.8 2
+      vertex -13.5725 12.8 5
+      vertex -19.5725 12.8 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -13.5725 12.8 5
+      vertex -19.5725 12.8 2
+      vertex -13.5725 12.8 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 13.5725 12.8 5
+      vertex 19.5725 12.8 6.5
+      vertex -13.5725 12.8 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 19.5725 12.8 2
+      vertex 13.5725 12.8 5
+      vertex 13.5725 12.8 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 13.5725 12.8 5
+      vertex 19.5725 12.8 2
+      vertex 19.5725 12.8 6.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0963 -7.51192 2
+      vertex -21.5725 -10.8 2
+      vertex -19.1738 -7.75051 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.1738 -7.75051 2
+      vertex -21.5725 -10.8 2
+      vertex -19.2 -8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -19.7816 12.789 2
+      vertex -20.1905 12.7021 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.2 -8 2
+      vertex -21.5725 -10.8 2
+      vertex -19.5725 -12.789 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -20.1905 12.7021 2
+      vertex -20.5725 12.5321 2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -20.5725 -12.5321 2
+      vertex -19.5725 -12.789 2
+      vertex -21.5725 -10.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -20.5725 12.5321 2
+      vertex -20.9108 12.2863 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -20.1905 -12.7021 2
+      vertex -19.7816 -12.789 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -20.9108 12.2863 2
+      vertex -21.1905 11.9756 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -20.5725 -12.5321 2
+      vertex -20.1905 -12.7021 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -21.1905 11.9756 2
+      vertex -21.3996 11.6135 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5725 -12.5321 2
+      vertex -21.5725 -10.8 2
+      vertex -20.9108 -12.2863 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -21.3996 11.6135 2
+      vertex -21.5288 11.2158 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9108 -12.2863 2
+      vertex -21.5725 -10.8 2
+      vertex -21.1905 -11.9756 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1905 -11.9756 2
+      vertex -21.5725 -10.8 2
+      vertex -21.3996 -11.6135 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.3996 -11.6135 2
+      vertex -21.5725 -10.8 2
+      vertex -21.5288 -11.2158 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.0292 7.29466 2
+      vertex -13.5725 11 2
+      vertex -16.9037 7.51192 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 -11 2
+      vertex -16.8262 -7.75051 2
+      vertex -16.8 -8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 11 2
+      vertex -17.0292 7.29466 2
+      vertex -13.5725 -11 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 -11 2
+      vertex -16.9037 -7.51192 2
+      vertex -16.8262 -7.75051 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.0292 -7.29466 2
+      vertex -13.5725 -11 2
+      vertex -17.0292 7.29466 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 -11 2
+      vertex -17.0292 -7.29466 2
+      vertex -16.9037 -7.51192 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.197 7.10823 2
+      vertex -17.0292 -7.29466 2
+      vertex -17.0292 7.29466 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.197 7.10823 2
+      vertex -17.197 -7.10823 2
+      vertex -17.0292 -7.29466 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.4 6.96077 2
+      vertex -17.197 -7.10823 2
+      vertex -17.197 7.10823 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4 6.96077 2
+      vertex -17.4 -6.96077 2
+      vertex -17.197 -7.10823 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.6292 6.85873 2
+      vertex -17.4 -6.96077 2
+      vertex -17.4 6.96077 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6292 6.85873 2
+      vertex -17.6292 -6.85873 2
+      vertex -17.4 -6.96077 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.8746 6.80657 2
+      vertex -17.6292 -6.85873 2
+      vertex -17.6292 6.85873 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8746 6.80657 2
+      vertex -17.8746 -6.80657 2
+      vertex -17.6292 -6.85873 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.1254 6.80657 2
+      vertex -17.8746 -6.80657 2
+      vertex -17.8746 6.80657 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.1254 6.80657 2
+      vertex -18.1254 -6.80657 2
+      vertex -17.8746 -6.80657 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3708 6.85873 2
+      vertex -18.1254 -6.80657 2
+      vertex -18.1254 6.80657 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3708 6.85873 2
+      vertex -18.3708 -6.85873 2
+      vertex -18.1254 -6.80657 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6 6.96077 2
+      vertex -18.3708 -6.85873 2
+      vertex -18.3708 6.85873 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6 6.96077 2
+      vertex -18.6 -6.96077 2
+      vertex -18.3708 -6.85873 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.803 7.10823 2
+      vertex -18.6 -6.96077 2
+      vertex -18.6 6.96077 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.803 7.10823 2
+      vertex -18.803 -7.10823 2
+      vertex -18.6 -6.96077 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9708 7.29466 2
+      vertex -18.803 -7.10823 2
+      vertex -18.803 7.10823 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9708 7.29466 2
+      vertex -18.9708 -7.29466 2
+      vertex -18.803 -7.10823 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0963 7.51192 2
+      vertex -18.9708 -7.29466 2
+      vertex -18.9708 7.29466 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0963 7.51192 2
+      vertex -19.0963 -7.51192 2
+      vertex -18.9708 -7.29466 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -19.0963 7.51192 2
+      vertex -19.1738 7.75051 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0963 7.51192 2
+      vertex -21.5725 10.8 2
+      vertex -19.0963 -7.51192 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -19.1738 7.75051 2
+      vertex -19.2 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 -10.8 2
+      vertex -19.0963 -7.51192 2
+      vertex -21.5725 10.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6292 9.14127 2
+      vertex -13.5725 11 2
+      vertex -13.5725 12.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.8262 7.75051 2
+      vertex -13.5725 11 2
+      vertex -16.8 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9037 7.51192 2
+      vertex -13.5725 11 2
+      vertex -16.8262 7.75051 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 11 2
+      vertex -16.8262 8.24949 2
+      vertex -16.8 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 11 2
+      vertex -16.9037 8.48808 2
+      vertex -16.8262 8.24949 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 11 2
+      vertex -17.0292 8.70534 2
+      vertex -16.9037 8.48808 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 11 2
+      vertex -17.197 8.89177 2
+      vertex -17.0292 8.70534 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 11 2
+      vertex -17.4 9.03923 2
+      vertex -17.197 8.89177 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 11 2
+      vertex -17.6292 9.14127 2
+      vertex -17.4 9.03923 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.5725 12.789 2
+      vertex -17.6292 9.14127 2
+      vertex -13.5725 12.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6292 9.14127 2
+      vertex -19.5725 12.789 2
+      vertex -17.8746 9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8746 9.19343 2
+      vertex -19.5725 12.789 2
+      vertex -18.1254 9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.1254 9.19343 2
+      vertex -19.5725 12.789 2
+      vertex -18.3708 9.14127 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3708 9.14127 2
+      vertex -19.5725 12.789 2
+      vertex -18.6 9.03923 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9708 8.70534 2
+      vertex -21.5725 10.8 2
+      vertex -19.0963 8.48808 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.803 8.89177 2
+      vertex -21.5725 10.8 2
+      vertex -18.9708 8.70534 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6 9.03923 2
+      vertex -21.5725 10.8 2
+      vertex -18.803 8.89177 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 12.789 2
+      vertex -21.5725 10.8 2
+      vertex -18.6 9.03923 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -19.5725 12.789 2
+      vertex -19.7816 12.789 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 12.789 2
+      vertex -13.5725 12.8 2
+      vertex -19.5725 12.8 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.5725 11 2
+      vertex 13.5725 -11 2
+      vertex 13.5725 11 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -11 2
+      vertex -13.5725 11 2
+      vertex -13.5725 -11 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.8262 -8.24949 2
+      vertex -13.5725 -11 2
+      vertex -16.8 -8 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.9037 -8.48808 2
+      vertex -13.5725 -11 2
+      vertex -16.8262 -8.24949 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.0292 -8.70534 2
+      vertex -13.5725 -11 2
+      vertex -16.9037 -8.48808 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.197 -8.89177 2
+      vertex -13.5725 -11 2
+      vertex -17.0292 -8.70534 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.4 -9.03923 2
+      vertex -13.5725 -11 2
+      vertex -17.197 -8.89177 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.6292 -9.14127 2
+      vertex -13.5725 -11 2
+      vertex -17.4 -9.03923 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 -11 2
+      vertex -17.6292 -9.14127 2
+      vertex -13.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -17.6292 -9.14127 2
+      vertex -17.8746 -9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -17.8746 -9.19343 2
+      vertex -18.1254 -9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -18.1254 -9.19343 2
+      vertex -18.3708 -9.14127 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -18.3708 -9.14127 2
+      vertex -18.6 -9.03923 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -18.6 -9.03923 2
+      vertex -18.803 -8.89177 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0963 8.48808 2
+      vertex -21.5725 10.8 2
+      vertex -19.1738 8.24949 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.1738 8.24949 2
+      vertex -21.5725 10.8 2
+      vertex -19.2 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -19.1738 -8.24949 2
+      vertex -19.2 -8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -19.0963 -8.48808 2
+      vertex -19.1738 -8.24949 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -18.9708 -8.70534 2
+      vertex -19.0963 -8.48808 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -18.803 -8.89177 2
+      vertex -18.9708 -8.70534 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6292 -9.14127 2
+      vertex -19.5725 -12.789 2
+      vertex -13.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5725 -12.8 2
+      vertex -19.5725 -12.789 2
+      vertex -19.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.1738 7.75051 2
+      vertex 19.2 -8 2
+      vertex 19.2 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.1738 7.75051 2
+      vertex 19.1738 -7.75051 2
+      vertex 19.2 -8 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.0963 7.51192 2
+      vertex 19.1738 -7.75051 2
+      vertex 19.1738 7.75051 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0963 7.51192 2
+      vertex 19.0963 -7.51192 2
+      vertex 19.1738 -7.75051 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.9708 7.29466 2
+      vertex 19.0963 -7.51192 2
+      vertex 19.0963 7.51192 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9708 7.29466 2
+      vertex 18.9708 -7.29466 2
+      vertex 19.0963 -7.51192 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.803 7.10823 2
+      vertex 18.9708 -7.29466 2
+      vertex 18.9708 7.29466 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.803 7.10823 2
+      vertex 18.803 -7.10823 2
+      vertex 18.9708 -7.29466 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.6 6.96077 2
+      vertex 18.803 -7.10823 2
+      vertex 18.803 7.10823 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6 6.96077 2
+      vertex 18.6 -6.96077 2
+      vertex 18.803 -7.10823 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.3708 6.85873 2
+      vertex 18.6 -6.96077 2
+      vertex 18.6 6.96077 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3708 6.85873 2
+      vertex 18.3708 -6.85873 2
+      vertex 18.6 -6.96077 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.1254 6.80657 2
+      vertex 18.3708 -6.85873 2
+      vertex 18.3708 6.85873 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.1254 6.80657 2
+      vertex 18.1254 -6.80657 2
+      vertex 18.3708 -6.85873 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.8746 6.80657 2
+      vertex 18.1254 -6.80657 2
+      vertex 18.1254 6.80657 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8746 6.80657 2
+      vertex 17.8746 -6.80657 2
+      vertex 18.1254 -6.80657 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6292 6.85873 2
+      vertex 17.8746 -6.80657 2
+      vertex 17.8746 6.80657 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6292 6.85873 2
+      vertex 17.6292 -6.85873 2
+      vertex 17.8746 -6.80657 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4 6.96077 2
+      vertex 17.6292 -6.85873 2
+      vertex 17.6292 6.85873 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4 6.96077 2
+      vertex 17.4 -6.96077 2
+      vertex 17.6292 -6.85873 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.197 7.10823 2
+      vertex 17.4 -6.96077 2
+      vertex 17.4 6.96077 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.197 7.10823 2
+      vertex 17.197 -7.10823 2
+      vertex 17.4 -6.96077 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0292 7.29466 2
+      vertex 17.197 -7.10823 2
+      vertex 17.197 7.10823 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0292 7.29466 2
+      vertex 17.0292 -7.29466 2
+      vertex 17.197 -7.10823 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 11 2
+      vertex 17.0292 7.29466 2
+      vertex 16.9037 7.51192 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0292 7.29466 2
+      vertex 13.5725 11 2
+      vertex 17.0292 -7.29466 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 11 2
+      vertex 16.9037 7.51192 2
+      vertex 16.8262 7.75051 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -11 2
+      vertex 17.0292 -7.29466 2
+      vertex 13.5725 11 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 11 2
+      vertex 16.8262 7.75051 2
+      vertex 16.8 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0292 -7.29466 2
+      vertex 13.5725 -11 2
+      vertex 16.9037 -7.51192 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.5725 12.8 2
+      vertex 19.5725 12.789 2
+      vertex 19.5725 12.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 19.2 8 2
+      vertex 19.5725 -12.789 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.2 -8 2
+      vertex 19.5725 -12.789 2
+      vertex 19.2 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 19.1738 8.24949 2
+      vertex 19.2 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 19.0963 8.48808 2
+      vertex 19.1738 8.24949 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 18.9708 8.70534 2
+      vertex 19.0963 8.48808 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 18.803 8.89177 2
+      vertex 18.9708 8.70534 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 18.6 9.03923 2
+      vertex 18.803 8.89177 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 18.3708 9.14127 2
+      vertex 18.6 9.03923 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 18.1254 9.19343 2
+      vertex 18.3708 9.14127 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 17.8746 9.19343 2
+      vertex 18.1254 9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 17.6292 9.14127 2
+      vertex 17.8746 9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 13.5725 12.8 2
+      vertex 17.6292 9.14127 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.5725 11 2
+      vertex 17.6292 9.14127 2
+      vertex 13.5725 12.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6292 9.14127 2
+      vertex 13.5725 11 2
+      vertex 17.4 9.03923 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.8262 8.24949 2
+      vertex 13.5725 11 2
+      vertex 16.8 8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9037 8.48808 2
+      vertex 13.5725 11 2
+      vertex 16.8262 8.24949 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0292 8.70534 2
+      vertex 13.5725 11 2
+      vertex 16.9037 8.48808 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.197 8.89177 2
+      vertex 13.5725 11 2
+      vertex 17.0292 8.70534 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4 9.03923 2
+      vertex 13.5725 11 2
+      vertex 17.197 8.89177 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 21.5725 10.8 2
+      vertex 21.5288 11.2158 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5725 10.8 2
+      vertex 19.5725 12.789 2
+      vertex 21.5725 -10.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 21.5288 11.2158 2
+      vertex 21.3996 11.6135 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 -12.789 2
+      vertex 21.5725 -10.8 2
+      vertex 19.5725 12.789 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 21.3996 11.6135 2
+      vertex 21.1905 11.9756 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5725 -10.8 2
+      vertex 19.5725 -12.789 2
+      vertex 21.5288 -11.2158 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 21.1905 11.9756 2
+      vertex 20.9108 12.2863 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5288 -11.2158 2
+      vertex 19.5725 -12.789 2
+      vertex 21.3996 -11.6135 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 20.9108 12.2863 2
+      vertex 20.5725 12.5321 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.3996 -11.6135 2
+      vertex 19.5725 -12.789 2
+      vertex 21.1905 -11.9756 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 20.5725 12.5321 2
+      vertex 20.1905 12.7021 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.1905 -11.9756 2
+      vertex 19.5725 -12.789 2
+      vertex 20.9108 -12.2863 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 20.1905 12.7021 2
+      vertex 19.7816 12.789 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.9108 -12.2863 2
+      vertex 19.5725 -12.789 2
+      vertex 20.5725 -12.5321 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5725 -12.5321 2
+      vertex 19.5725 -12.789 2
+      vertex 20.1905 -12.7021 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1905 -12.7021 2
+      vertex 19.5725 -12.789 2
+      vertex 19.7816 -12.789 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.1738 -8.24949 2
+      vertex 19.5725 -12.789 2
+      vertex 19.2 -8 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.0963 -8.48808 2
+      vertex 19.5725 -12.789 2
+      vertex 19.1738 -8.24949 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.9708 -8.70534 2
+      vertex 19.5725 -12.789 2
+      vertex 19.0963 -8.48808 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.803 -8.89177 2
+      vertex 19.5725 -12.789 2
+      vertex 18.9708 -8.70534 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.6 -9.03923 2
+      vertex 19.5725 -12.789 2
+      vertex 18.803 -8.89177 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.3708 -9.14127 2
+      vertex 19.5725 -12.789 2
+      vertex 18.6 -9.03923 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.1254 -9.19343 2
+      vertex 19.5725 -12.789 2
+      vertex 18.3708 -9.14127 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.8746 -9.19343 2
+      vertex 19.5725 -12.789 2
+      vertex 18.1254 -9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6292 -9.14127 2
+      vertex 19.5725 -12.789 2
+      vertex 17.8746 -9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -12.8 2
+      vertex 19.5725 -12.789 2
+      vertex 17.6292 -9.14127 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -11 2
+      vertex 17.6292 -9.14127 2
+      vertex 17.4 -9.03923 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -11 2
+      vertex 17.4 -9.03923 2
+      vertex 17.197 -8.89177 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -11 2
+      vertex 17.197 -8.89177 2
+      vertex 17.0292 -8.70534 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9037 -7.51192 2
+      vertex 13.5725 -11 2
+      vertex 16.8262 -7.75051 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.8262 -7.75051 2
+      vertex 13.5725 -11 2
+      vertex 16.8 -8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.8 -8 2
+      vertex 13.5725 -11 2
+      vertex 16.8262 -8.24949 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -11 2
+      vertex 16.9037 -8.48808 2
+      vertex 16.8262 -8.24949 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -11 2
+      vertex 17.0292 -8.70534 2
+      vertex 16.9037 -8.48808 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6292 -9.14127 2
+      vertex 13.5725 -11 2
+      vertex 13.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 -12.789 2
+      vertex 13.5725 -12.8 2
+      vertex 19.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.5725 -12.8 6.5
+      vertex 13.5725 -12.8 5
+      vertex -19.5725 -12.8 6.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 19.5725 -12.8 2
+      vertex 13.5725 -12.8 5
+      vertex 19.5725 -12.8 6.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 13.5725 -12.8 5
+      vertex 19.5725 -12.8 2
+      vertex 13.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -13.5725 -12.8 5
+      vertex -19.5725 -12.8 6.5
+      vertex 13.5725 -12.8 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -19.5725 -12.8 2
+      vertex -13.5725 -12.8 5
+      vertex -13.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.5725 -12.8 5
+      vertex -19.5725 -12.8 2
+      vertex -19.5725 -12.8 6.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -21.5725 -10.8 6.5
+      vertex -21.5725 10.8 2
+      vertex -21.5725 10.8 6.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -21.5725 10.8 2
+      vertex -21.5725 -10.8 6.5
+      vertex -21.5725 -10.8 2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 21.5725 10.8 2
+      vertex 21.5725 5 3.75
+      vertex 21.5725 10.8 6.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 21.5725 10.8 2
+      vertex 21.5725 -5 3.75
+      vertex 21.5725 5 3.75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 21.5725 -10.8 2
+      vertex 21.5725 -5 3.75
+      vertex 21.5725 10.8 2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 21.5725 -10.8 6.5
+      vertex 21.5725 -5 3.75
+      vertex 21.5725 -10.8 2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 21.5725 -5 3.75
+      vertex 21.5725 -10.8 6.5
+      vertex 21.5725 -5 6.5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 21.5725 10.8 6.5
+      vertex 21.5725 5 3.75
+      vertex 21.5725 5 6.5
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104523 0
+    outer loop
+      vertex 21.5725 10.8 2
+      vertex 21.5288 11.2158 6.5
+      vertex 21.5288 11.2158 2
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104523 0
+    outer loop
+      vertex 21.5288 11.2158 6.5
+      vertex 21.5725 10.8 2
+      vertex 21.5725 10.8 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 19.5725 12.789 2
+      vertex 19.7816 12.789 6.5
+      vertex 19.5725 12.789 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 19.7816 12.789 6.5
+      vertex 19.5725 12.789 2
+      vertex 19.7816 12.789 2
+    endloop
+  endfacet
+  facet normal -0.743211 -0.669057 0
+    outer loop
+      vertex 21.1905 11.9756 2
+      vertex 20.9108 12.2863 6.5
+      vertex 20.9108 12.2863 2
+    endloop
+  endfacet
+  facet normal -0.743211 -0.669057 0
+    outer loop
+      vertex 20.9108 12.2863 6.5
+      vertex 21.1905 11.9756 2
+      vertex 21.1905 11.9756 6.5
+    endloop
+  endfacet
+  facet normal -0.951071 -0.308973 0
+    outer loop
+      vertex 21.5288 11.2158 2
+      vertex 21.3996 11.6135 6.5
+      vertex 21.3996 11.6135 2
+    endloop
+  endfacet
+  facet normal -0.951071 -0.308973 0
+    outer loop
+      vertex 21.3996 11.6135 6.5
+      vertex 21.5288 11.2158 2
+      vertex 21.5288 11.2158 6.5
+    endloop
+  endfacet
+  facet normal -0.865982 -0.500074 0
+    outer loop
+      vertex 21.3996 11.6135 2
+      vertex 21.1905 11.9756 6.5
+      vertex 21.1905 11.9756 2
+    endloop
+  endfacet
+  facet normal -0.865982 -0.500074 0
+    outer loop
+      vertex 21.1905 11.9756 6.5
+      vertex 21.3996 11.6135 2
+      vertex 21.3996 11.6135 6.5
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 0
+    outer loop
+      vertex 20.1905 12.7021 2
+      vertex 20.5725 12.5321 6.5
+      vertex 20.1905 12.7021 6.5
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 -0
+    outer loop
+      vertex 20.5725 12.5321 6.5
+      vertex 20.1905 12.7021 2
+      vertex 20.5725 12.5321 2
+    endloop
+  endfacet
+  facet normal -0.207879 -0.978155 0
+    outer loop
+      vertex 19.7816 12.789 2
+      vertex 20.1905 12.7021 6.5
+      vertex 19.7816 12.789 6.5
+    endloop
+  endfacet
+  facet normal -0.207879 -0.978155 -0
+    outer loop
+      vertex 20.1905 12.7021 6.5
+      vertex 19.7816 12.789 2
+      vertex 20.1905 12.7021 2
+    endloop
+  endfacet
+  facet normal -0.587802 -0.809005 0
+    outer loop
+      vertex 20.5725 12.5321 2
+      vertex 20.9108 12.2863 6.5
+      vertex 20.5725 12.5321 6.5
+    endloop
+  endfacet
+  facet normal -0.587802 -0.809005 -0
+    outer loop
+      vertex 20.9108 12.2863 6.5
+      vertex 20.5725 12.5321 2
+      vertex 20.9108 12.2863 2
+    endloop
+  endfacet
+  facet normal -0.865982 0.500074 0
+    outer loop
+      vertex 21.1905 -11.9756 2
+      vertex 21.3996 -11.6135 6.5
+      vertex 21.3996 -11.6135 2
+    endloop
+  endfacet
+  facet normal -0.865982 0.500074 0
+    outer loop
+      vertex 21.3996 -11.6135 6.5
+      vertex 21.1905 -11.9756 2
+      vertex 21.1905 -11.9756 6.5
+    endloop
+  endfacet
+  facet normal -0.994522 0.104523 0
+    outer loop
+      vertex 21.5288 -11.2158 2
+      vertex 21.5725 -10.8 6.5
+      vertex 21.5725 -10.8 2
+    endloop
+  endfacet
+  facet normal -0.994522 0.104523 0
+    outer loop
+      vertex 21.5725 -10.8 6.5
+      vertex 21.5288 -11.2158 2
+      vertex 21.5288 -11.2158 6.5
+    endloop
+  endfacet
+  facet normal -0.207879 0.978155 0
+    outer loop
+      vertex 20.1905 -12.7021 2
+      vertex 19.7816 -12.789 6.5
+      vertex 20.1905 -12.7021 6.5
+    endloop
+  endfacet
+  facet normal -0.207879 0.978155 0
+    outer loop
+      vertex 19.7816 -12.789 6.5
+      vertex 20.1905 -12.7021 2
+      vertex 19.7816 -12.789 2
+    endloop
+  endfacet
+  facet normal -0.587802 0.809005 0
+    outer loop
+      vertex 20.9108 -12.2863 2
+      vertex 20.5725 -12.5321 6.5
+      vertex 20.9108 -12.2863 6.5
+    endloop
+  endfacet
+  facet normal -0.587802 0.809005 0
+    outer loop
+      vertex 20.5725 -12.5321 6.5
+      vertex 20.9108 -12.2863 2
+      vertex 20.5725 -12.5321 2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 19.7816 -12.789 2
+      vertex 19.5725 -12.789 6.5
+      vertex 19.7816 -12.789 6.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.5725 -12.789 6.5
+      vertex 19.7816 -12.789 2
+      vertex 19.5725 -12.789 2
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex 20.5725 -12.5321 2
+      vertex 20.1905 -12.7021 6.5
+      vertex 20.5725 -12.5321 6.5
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex 20.1905 -12.7021 6.5
+      vertex 20.5725 -12.5321 2
+      vertex 20.1905 -12.7021 2
+    endloop
+  endfacet
+  facet normal -0.743211 0.669057 0
+    outer loop
+      vertex 20.9108 -12.2863 2
+      vertex 21.1905 -11.9756 6.5
+      vertex 21.1905 -11.9756 2
+    endloop
+  endfacet
+  facet normal -0.743211 0.669057 0
+    outer loop
+      vertex 21.1905 -11.9756 6.5
+      vertex 20.9108 -12.2863 2
+      vertex 20.9108 -12.2863 6.5
+    endloop
+  endfacet
+  facet normal -0.951071 0.308973 0
+    outer loop
+      vertex 21.3996 -11.6135 2
+      vertex 21.5288 -11.2158 6.5
+      vertex 21.5288 -11.2158 2
+    endloop
+  endfacet
+  facet normal -0.951071 0.308973 0
+    outer loop
+      vertex 21.5288 -11.2158 6.5
+      vertex 21.3996 -11.6135 2
+      vertex 21.3996 -11.6135 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -19.7816 12.789 2
+      vertex -19.5725 12.789 6.5
+      vertex -19.7816 12.789 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -19.5725 12.789 6.5
+      vertex -19.7816 12.789 2
+      vertex -19.5725 12.789 2
+    endloop
+  endfacet
+  facet normal 0.951071 -0.308973 0
+    outer loop
+      vertex -21.5288 11.2158 6.5
+      vertex -21.3996 11.6135 2
+      vertex -21.3996 11.6135 6.5
+    endloop
+  endfacet
+  facet normal 0.951071 -0.308973 0
+    outer loop
+      vertex -21.3996 11.6135 2
+      vertex -21.5288 11.2158 6.5
+      vertex -21.5288 11.2158 2
+    endloop
+  endfacet
+  facet normal 0.207879 -0.978155 0
+    outer loop
+      vertex -20.1905 12.7021 2
+      vertex -19.7816 12.789 6.5
+      vertex -20.1905 12.7021 6.5
+    endloop
+  endfacet
+  facet normal 0.207879 -0.978155 0
+    outer loop
+      vertex -19.7816 12.789 6.5
+      vertex -20.1905 12.7021 2
+      vertex -19.7816 12.789 2
+    endloop
+  endfacet
+  facet normal 0.865982 -0.500074 0
+    outer loop
+      vertex -21.3996 11.6135 6.5
+      vertex -21.1905 11.9756 2
+      vertex -21.1905 11.9756 6.5
+    endloop
+  endfacet
+  facet normal 0.865982 -0.500074 0
+    outer loop
+      vertex -21.1905 11.9756 2
+      vertex -21.3996 11.6135 6.5
+      vertex -21.3996 11.6135 2
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104523 0
+    outer loop
+      vertex -21.5725 10.8 6.5
+      vertex -21.5288 11.2158 2
+      vertex -21.5288 11.2158 6.5
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104523 0
+    outer loop
+      vertex -21.5288 11.2158 2
+      vertex -21.5725 10.8 6.5
+      vertex -21.5725 10.8 2
+    endloop
+  endfacet
+  facet normal 0.743211 -0.669057 0
+    outer loop
+      vertex -21.1905 11.9756 6.5
+      vertex -20.9108 12.2863 2
+      vertex -20.9108 12.2863 6.5
+    endloop
+  endfacet
+  facet normal 0.743211 -0.669057 0
+    outer loop
+      vertex -20.9108 12.2863 2
+      vertex -21.1905 11.9756 6.5
+      vertex -21.1905 11.9756 2
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex -20.5725 12.5321 2
+      vertex -20.1905 12.7021 6.5
+      vertex -20.5725 12.5321 6.5
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex -20.1905 12.7021 6.5
+      vertex -20.5725 12.5321 2
+      vertex -20.1905 12.7021 2
+    endloop
+  endfacet
+  facet normal 0.587802 -0.809005 0
+    outer loop
+      vertex -20.9108 12.2863 2
+      vertex -20.5725 12.5321 6.5
+      vertex -20.9108 12.2863 6.5
+    endloop
+  endfacet
+  facet normal 0.587802 -0.809005 0
+    outer loop
+      vertex -20.5725 12.5321 6.5
+      vertex -20.9108 12.2863 2
+      vertex -20.5725 12.5321 2
+    endloop
+  endfacet
+  facet normal 0.207879 0.978155 -0
+    outer loop
+      vertex -19.7816 -12.789 2
+      vertex -20.1905 -12.7021 6.5
+      vertex -19.7816 -12.789 6.5
+    endloop
+  endfacet
+  facet normal 0.207879 0.978155 0
+    outer loop
+      vertex -20.1905 -12.7021 6.5
+      vertex -19.7816 -12.789 2
+      vertex -20.1905 -12.7021 2
+    endloop
+  endfacet
+  facet normal 0.951071 0.308973 0
+    outer loop
+      vertex -21.3996 -11.6135 6.5
+      vertex -21.5288 -11.2158 2
+      vertex -21.5288 -11.2158 6.5
+    endloop
+  endfacet
+  facet normal 0.951071 0.308973 0
+    outer loop
+      vertex -21.5288 -11.2158 2
+      vertex -21.3996 -11.6135 6.5
+      vertex -21.3996 -11.6135 2
+    endloop
+  endfacet
+  facet normal 0.994522 0.104523 0
+    outer loop
+      vertex -21.5288 -11.2158 6.5
+      vertex -21.5725 -10.8 2
+      vertex -21.5725 -10.8 6.5
+    endloop
+  endfacet
+  facet normal 0.994522 0.104523 0
+    outer loop
+      vertex -21.5725 -10.8 2
+      vertex -21.5288 -11.2158 6.5
+      vertex -21.5288 -11.2158 2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -19.5725 -12.789 2
+      vertex -19.7816 -12.789 6.5
+      vertex -19.5725 -12.789 6.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -19.7816 -12.789 6.5
+      vertex -19.5725 -12.789 2
+      vertex -19.7816 -12.789 2
+    endloop
+  endfacet
+  facet normal 0.587802 0.809005 -0
+    outer loop
+      vertex -20.5725 -12.5321 2
+      vertex -20.9108 -12.2863 6.5
+      vertex -20.5725 -12.5321 6.5
+    endloop
+  endfacet
+  facet normal 0.587802 0.809005 0
+    outer loop
+      vertex -20.9108 -12.2863 6.5
+      vertex -20.5725 -12.5321 2
+      vertex -20.9108 -12.2863 2
+    endloop
+  endfacet
+  facet normal 0.865982 0.500074 0
+    outer loop
+      vertex -21.1905 -11.9756 6.5
+      vertex -21.3996 -11.6135 2
+      vertex -21.3996 -11.6135 6.5
+    endloop
+  endfacet
+  facet normal 0.865982 0.500074 0
+    outer loop
+      vertex -21.3996 -11.6135 2
+      vertex -21.1905 -11.9756 6.5
+      vertex -21.1905 -11.9756 2
+    endloop
+  endfacet
+  facet normal 0.743211 0.669057 0
+    outer loop
+      vertex -20.9108 -12.2863 6.5
+      vertex -21.1905 -11.9756 2
+      vertex -21.1905 -11.9756 6.5
+    endloop
+  endfacet
+  facet normal 0.743211 0.669057 0
+    outer loop
+      vertex -21.1905 -11.9756 2
+      vertex -20.9108 -12.2863 6.5
+      vertex -20.9108 -12.2863 2
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 -0
+    outer loop
+      vertex -20.1905 -12.7021 2
+      vertex -20.5725 -12.5321 6.5
+      vertex -20.1905 -12.7021 6.5
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 0
+    outer loop
+      vertex -20.5725 -12.5321 6.5
+      vertex -20.1905 -12.7021 2
+      vertex -20.5725 -12.5321 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.5725 5 3.75
+      vertex 22.2725 5 6.5
+      vertex 21.5725 5 6.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 22.2725 5 6.5
+      vertex 21.5725 5 3.75
+      vertex 22.2725 5 3.75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.5725 5 3.75
+      vertex 22.2725 -5 3.75
+      vertex 22.2725 5 3.75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2725 -5 3.75
+      vertex 21.5725 5 3.75
+      vertex 21.5725 -5 3.75
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 22.2725 -5 3.75
+      vertex 21.5725 -5 6.5
+      vertex 22.2725 -5 6.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.5725 -5 6.5
+      vertex 22.2725 -5 3.75
+      vertex 21.5725 -5 3.75
+    endloop
+  endfacet
+  facet normal 0.865913 0.500194 0
+    outer loop
+      vertex 19.0963 8.48808 5
+      vertex 18.9708 8.70534 2
+      vertex 18.9708 8.70534 5
+    endloop
+  endfacet
+  facet normal 0.865913 0.500194 0
+    outer loop
+      vertex 18.9708 8.70534 2
+      vertex 19.0963 8.48808 5
+      vertex 19.0963 8.48808 2
+    endloop
+  endfacet
+  facet normal 0.994531 0.10444 0
+    outer loop
+      vertex 19.2 8 5
+      vertex 19.1738 8.24949 2
+      vertex 19.1738 8.24949 5
+    endloop
+  endfacet
+  facet normal 0.994531 0.10444 0
+    outer loop
+      vertex 19.1738 8.24949 2
+      vertex 19.2 8 5
+      vertex 19.2 8 2
+    endloop
+  endfacet
+  facet normal -0.994531 -0.10444 0
+    outer loop
+      vertex 16.8262 7.75051 2
+      vertex 16.8 8 5
+      vertex 16.8 8 2
+    endloop
+  endfacet
+  facet normal -0.994531 -0.10444 0
+    outer loop
+      vertex 16.8 8 5
+      vertex 16.8262 7.75051 2
+      vertex 16.8262 7.75051 5
+    endloop
+  endfacet
+  facet normal 0.743268 0.668993 0
+    outer loop
+      vertex 18.9708 8.70534 5
+      vertex 18.803 8.89177 2
+      vertex 18.803 8.89177 5
+    endloop
+  endfacet
+  facet normal 0.743268 0.668993 0
+    outer loop
+      vertex 18.803 8.89177 2
+      vertex 18.9708 8.70534 5
+      vertex 18.9708 8.70534 2
+    endloop
+  endfacet
+  facet normal 0.207906 0.978149 -0
+    outer loop
+      vertex 18.3708 9.14127 2
+      vertex 18.1254 9.19343 5
+      vertex 18.3708 9.14127 5
+    endloop
+  endfacet
+  facet normal 0.207906 0.978149 0
+    outer loop
+      vertex 18.1254 9.19343 5
+      vertex 18.3708 9.14127 2
+      vertex 18.1254 9.19343 2
+    endloop
+  endfacet
+  facet normal -0.587712 0.80907 0
+    outer loop
+      vertex 17.4 9.03923 2
+      vertex 17.197 8.89177 5
+      vertex 17.4 9.03923 5
+    endloop
+  endfacet
+  facet normal -0.587712 0.80907 0
+    outer loop
+      vertex 17.197 8.89177 5
+      vertex 17.4 9.03923 2
+      vertex 17.197 8.89177 2
+    endloop
+  endfacet
+  facet normal -0.994531 0.10444 0
+    outer loop
+      vertex 16.8 8 2
+      vertex 16.8262 8.24949 5
+      vertex 16.8262 8.24949 2
+    endloop
+  endfacet
+  facet normal -0.994531 0.10444 0
+    outer loop
+      vertex 16.8262 8.24949 5
+      vertex 16.8 8 2
+      vertex 16.8 8 5
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex 18.3708 6.85873 2
+      vertex 18.6 6.96077 5
+      vertex 18.3708 6.85873 5
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex 18.6 6.96077 5
+      vertex 18.3708 6.85873 2
+      vertex 18.6 6.96077 2
+    endloop
+  endfacet
+  facet normal 0.587712 0.80907 -0
+    outer loop
+      vertex 18.803 8.89177 2
+      vertex 18.6 9.03923 5
+      vertex 18.803 8.89177 5
+    endloop
+  endfacet
+  facet normal 0.587712 0.80907 0
+    outer loop
+      vertex 18.6 9.03923 5
+      vertex 18.803 8.89177 2
+      vertex 18.6 9.03923 2
+    endloop
+  endfacet
+  facet normal -0.207906 0.978149 0
+    outer loop
+      vertex 17.8746 9.19343 2
+      vertex 17.6292 9.14127 5
+      vertex 17.8746 9.19343 5
+    endloop
+  endfacet
+  facet normal -0.207906 0.978149 0
+    outer loop
+      vertex 17.6292 9.14127 5
+      vertex 17.8746 9.19343 2
+      vertex 17.6292 9.14127 2
+    endloop
+  endfacet
+  facet normal 0.406715 0.913555 -0
+    outer loop
+      vertex 18.6 9.03923 2
+      vertex 18.3708 9.14127 5
+      vertex 18.6 9.03923 5
+    endloop
+  endfacet
+  facet normal 0.406715 0.913555 0
+    outer loop
+      vertex 18.3708 9.14127 5
+      vertex 18.6 9.03923 2
+      vertex 18.3708 9.14127 2
+    endloop
+  endfacet
+  facet normal -0.951083 0.308936 0
+    outer loop
+      vertex 16.8262 8.24949 2
+      vertex 16.9037 8.48808 5
+      vertex 16.9037 8.48808 2
+    endloop
+  endfacet
+  facet normal -0.951083 0.308936 0
+    outer loop
+      vertex 16.9037 8.48808 5
+      vertex 16.8262 8.24949 2
+      vertex 16.8262 8.24949 5
+    endloop
+  endfacet
+  facet normal -0.743268 0.668993 0
+    outer loop
+      vertex 17.0292 8.70534 2
+      vertex 17.197 8.89177 5
+      vertex 17.197 8.89177 2
+    endloop
+  endfacet
+  facet normal -0.743268 0.668993 0
+    outer loop
+      vertex 17.197 8.89177 5
+      vertex 17.0292 8.70534 2
+      vertex 17.0292 8.70534 5
+    endloop
+  endfacet
+  facet normal -0.406715 0.913555 0
+    outer loop
+      vertex 17.6292 9.14127 2
+      vertex 17.4 9.03923 5
+      vertex 17.6292 9.14127 5
+    endloop
+  endfacet
+  facet normal -0.406715 0.913555 0
+    outer loop
+      vertex 17.4 9.03923 5
+      vertex 17.6292 9.14127 2
+      vertex 17.4 9.03923 2
+    endloop
+  endfacet
+  facet normal -0.865913 0.500194 0
+    outer loop
+      vertex 16.9037 8.48808 2
+      vertex 17.0292 8.70534 5
+      vertex 17.0292 8.70534 2
+    endloop
+  endfacet
+  facet normal -0.865913 0.500194 0
+    outer loop
+      vertex 17.0292 8.70534 5
+      vertex 16.9037 8.48808 2
+      vertex 16.9037 8.48808 5
+    endloop
+  endfacet
+  facet normal 0.951083 -0.308936 0
+    outer loop
+      vertex 19.0963 7.51192 5
+      vertex 19.1738 7.75051 2
+      vertex 19.1738 7.75051 5
+    endloop
+  endfacet
+  facet normal 0.951083 -0.308936 0
+    outer loop
+      vertex 19.1738 7.75051 2
+      vertex 19.0963 7.51192 5
+      vertex 19.0963 7.51192 2
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 0
+    outer loop
+      vertex 17.4 6.96077 2
+      vertex 17.6292 6.85873 5
+      vertex 17.4 6.96077 5
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 -0
+    outer loop
+      vertex 17.6292 6.85873 5
+      vertex 17.4 6.96077 2
+      vertex 17.6292 6.85873 2
+    endloop
+  endfacet
+  facet normal -0.743268 -0.668993 0
+    outer loop
+      vertex 17.197 7.10823 2
+      vertex 17.0292 7.29466 5
+      vertex 17.0292 7.29466 2
+    endloop
+  endfacet
+  facet normal -0.743268 -0.668993 0
+    outer loop
+      vertex 17.0292 7.29466 5
+      vertex 17.197 7.10823 2
+      vertex 17.197 7.10823 5
+    endloop
+  endfacet
+  facet normal 0.743268 -0.668993 0
+    outer loop
+      vertex 18.803 7.10823 5
+      vertex 18.9708 7.29466 2
+      vertex 18.9708 7.29466 5
+    endloop
+  endfacet
+  facet normal 0.743268 -0.668993 0
+    outer loop
+      vertex 18.9708 7.29466 2
+      vertex 18.803 7.10823 5
+      vertex 18.803 7.10823 2
+    endloop
+  endfacet
+  facet normal 0.994531 -0.10444 0
+    outer loop
+      vertex 19.1738 7.75051 5
+      vertex 19.2 8 2
+      vertex 19.2 8 5
+    endloop
+  endfacet
+  facet normal 0.994531 -0.10444 0
+    outer loop
+      vertex 19.2 8 2
+      vertex 19.1738 7.75051 5
+      vertex 19.1738 7.75051 2
+    endloop
+  endfacet
+  facet normal 0.951083 0.308936 0
+    outer loop
+      vertex 19.1738 8.24949 5
+      vertex 19.0963 8.48808 2
+      vertex 19.0963 8.48808 5
+    endloop
+  endfacet
+  facet normal 0.951083 0.308936 0
+    outer loop
+      vertex 19.0963 8.48808 2
+      vertex 19.1738 8.24949 5
+      vertex 19.1738 8.24949 2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.1254 9.19343 2
+      vertex 17.8746 9.19343 5
+      vertex 18.1254 9.19343 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.8746 9.19343 5
+      vertex 18.1254 9.19343 2
+      vertex 17.8746 9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.1738 8.24949 5
+      vertex 19.1738 7.75051 5
+      vertex 19.2 8 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0963 8.48808 5
+      vertex 19.1738 7.75051 5
+      vertex 19.1738 8.24949 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0963 8.48808 5
+      vertex 19.0963 7.51192 5
+      vertex 19.1738 7.75051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9708 8.70534 5
+      vertex 19.0963 7.51192 5
+      vertex 19.0963 8.48808 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9708 8.70534 5
+      vertex 18.9708 7.29466 5
+      vertex 19.0963 7.51192 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.803 8.89177 5
+      vertex 18.9708 7.29466 5
+      vertex 18.9708 8.70534 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.803 8.89177 5
+      vertex 18.803 7.10823 5
+      vertex 18.9708 7.29466 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6 9.03923 5
+      vertex 18.803 7.10823 5
+      vertex 18.803 8.89177 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6 9.03923 5
+      vertex 18.6 6.96077 5
+      vertex 18.803 7.10823 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3708 9.14127 5
+      vertex 18.6 6.96077 5
+      vertex 18.6 9.03923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3708 9.14127 5
+      vertex 18.3708 6.85873 5
+      vertex 18.6 6.96077 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.1254 9.19343 5
+      vertex 18.3708 6.85873 5
+      vertex 18.3708 9.14127 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.1254 9.19343 5
+      vertex 18.1254 6.80657 5
+      vertex 18.3708 6.85873 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.8746 9.19343 5
+      vertex 18.1254 6.80657 5
+      vertex 18.1254 9.19343 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8746 9.19343 5
+      vertex 17.8746 6.80657 5
+      vertex 18.1254 6.80657 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.6292 9.14127 5
+      vertex 17.8746 6.80657 5
+      vertex 17.8746 9.19343 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6292 9.14127 5
+      vertex 17.6292 6.85873 5
+      vertex 17.8746 6.80657 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.4 9.03923 5
+      vertex 17.6292 6.85873 5
+      vertex 17.6292 9.14127 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4 9.03923 5
+      vertex 17.4 6.96077 5
+      vertex 17.6292 6.85873 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.197 8.89177 5
+      vertex 17.4 6.96077 5
+      vertex 17.4 9.03923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.197 8.89177 5
+      vertex 17.197 7.10823 5
+      vertex 17.4 6.96077 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.0292 8.70534 5
+      vertex 17.197 7.10823 5
+      vertex 17.197 8.89177 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0292 8.70534 5
+      vertex 17.0292 7.29466 5
+      vertex 17.197 7.10823 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.9037 8.48808 5
+      vertex 17.0292 7.29466 5
+      vertex 17.0292 8.70534 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9037 8.48808 5
+      vertex 16.9037 7.51192 5
+      vertex 17.0292 7.29466 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.8262 8.24949 5
+      vertex 16.9037 7.51192 5
+      vertex 16.9037 8.48808 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.8262 8.24949 5
+      vertex 16.8262 7.75051 5
+      vertex 16.9037 7.51192 5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 16.8262 7.75051 5
+      vertex 16.8262 8.24949 5
+      vertex 16.8 8 5
+    endloop
+  endfacet
+  facet normal 0.207906 -0.978149 0
+    outer loop
+      vertex 18.1254 6.80657 2
+      vertex 18.3708 6.85873 5
+      vertex 18.1254 6.80657 5
+    endloop
+  endfacet
+  facet normal 0.207906 -0.978149 0
+    outer loop
+      vertex 18.3708 6.85873 5
+      vertex 18.1254 6.80657 2
+      vertex 18.3708 6.85873 2
+    endloop
+  endfacet
+  facet normal -0.587712 -0.80907 0
+    outer loop
+      vertex 17.197 7.10823 2
+      vertex 17.4 6.96077 5
+      vertex 17.197 7.10823 5
+    endloop
+  endfacet
+  facet normal -0.587712 -0.80907 -0
+    outer loop
+      vertex 17.4 6.96077 5
+      vertex 17.197 7.10823 2
+      vertex 17.4 6.96077 2
+    endloop
+  endfacet
+  facet normal 0.587712 -0.80907 0
+    outer loop
+      vertex 18.6 6.96077 2
+      vertex 18.803 7.10823 5
+      vertex 18.6 6.96077 5
+    endloop
+  endfacet
+  facet normal 0.587712 -0.80907 0
+    outer loop
+      vertex 18.803 7.10823 5
+      vertex 18.6 6.96077 2
+      vertex 18.803 7.10823 2
+    endloop
+  endfacet
+  facet normal -0.207906 -0.978149 0
+    outer loop
+      vertex 17.6292 6.85873 2
+      vertex 17.8746 6.80657 5
+      vertex 17.6292 6.85873 5
+    endloop
+  endfacet
+  facet normal -0.207906 -0.978149 -0
+    outer loop
+      vertex 17.8746 6.80657 5
+      vertex 17.6292 6.85873 2
+      vertex 17.8746 6.80657 2
+    endloop
+  endfacet
+  facet normal -0.865913 -0.500194 0
+    outer loop
+      vertex 17.0292 7.29466 2
+      vertex 16.9037 7.51192 5
+      vertex 16.9037 7.51192 2
+    endloop
+  endfacet
+  facet normal -0.865913 -0.500194 0
+    outer loop
+      vertex 16.9037 7.51192 5
+      vertex 17.0292 7.29466 2
+      vertex 17.0292 7.29466 5
+    endloop
+  endfacet
+  facet normal -0.951083 -0.308936 0
+    outer loop
+      vertex 16.9037 7.51192 2
+      vertex 16.8262 7.75051 5
+      vertex 16.8262 7.75051 2
+    endloop
+  endfacet
+  facet normal -0.951083 -0.308936 0
+    outer loop
+      vertex 16.8262 7.75051 5
+      vertex 16.9037 7.51192 2
+      vertex 16.9037 7.51192 5
+    endloop
+  endfacet
+  facet normal 0.865913 -0.500194 0
+    outer loop
+      vertex 18.9708 7.29466 5
+      vertex 19.0963 7.51192 2
+      vertex 19.0963 7.51192 5
+    endloop
+  endfacet
+  facet normal 0.865913 -0.500194 0
+    outer loop
+      vertex 19.0963 7.51192 2
+      vertex 18.9708 7.29466 5
+      vertex 18.9708 7.29466 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 17.8746 6.80657 2
+      vertex 18.1254 6.80657 5
+      vertex 17.8746 6.80657 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.1254 6.80657 5
+      vertex 17.8746 6.80657 2
+      vertex 18.1254 6.80657 2
+    endloop
+  endfacet
+  facet normal 0.994531 0.10444 0
+    outer loop
+      vertex 19.2 -8 5
+      vertex 19.1738 -7.75051 2
+      vertex 19.1738 -7.75051 5
+    endloop
+  endfacet
+  facet normal 0.994531 0.10444 0
+    outer loop
+      vertex 19.1738 -7.75051 2
+      vertex 19.2 -8 5
+      vertex 19.2 -8 2
+    endloop
+  endfacet
+  facet normal -0.994531 0.10444 0
+    outer loop
+      vertex 16.8 -8 2
+      vertex 16.8262 -7.75051 5
+      vertex 16.8262 -7.75051 2
+    endloop
+  endfacet
+  facet normal -0.994531 0.10444 0
+    outer loop
+      vertex 16.8262 -7.75051 5
+      vertex 16.8 -8 2
+      vertex 16.8 -8 5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.1254 -6.80657 2
+      vertex 17.8746 -6.80657 5
+      vertex 18.1254 -6.80657 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.8746 -6.80657 5
+      vertex 18.1254 -6.80657 2
+      vertex 17.8746 -6.80657 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 17.8746 -9.19343 2
+      vertex 18.1254 -9.19343 5
+      vertex 17.8746 -9.19343 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.1254 -9.19343 5
+      vertex 17.8746 -9.19343 2
+      vertex 18.1254 -9.19343 2
+    endloop
+  endfacet
+  facet normal 0.587712 0.80907 -0
+    outer loop
+      vertex 18.803 -7.10823 2
+      vertex 18.6 -6.96077 5
+      vertex 18.803 -7.10823 5
+    endloop
+  endfacet
+  facet normal 0.587712 0.80907 0
+    outer loop
+      vertex 18.6 -6.96077 5
+      vertex 18.803 -7.10823 2
+      vertex 18.6 -6.96077 2
+    endloop
+  endfacet
+  facet normal 0.406715 0.913555 -0
+    outer loop
+      vertex 18.6 -6.96077 2
+      vertex 18.3708 -6.85873 5
+      vertex 18.6 -6.96077 5
+    endloop
+  endfacet
+  facet normal 0.406715 0.913555 0
+    outer loop
+      vertex 18.3708 -6.85873 5
+      vertex 18.6 -6.96077 2
+      vertex 18.3708 -6.85873 2
+    endloop
+  endfacet
+  facet normal -0.587712 0.80907 0
+    outer loop
+      vertex 17.4 -6.96077 2
+      vertex 17.197 -7.10823 5
+      vertex 17.4 -6.96077 5
+    endloop
+  endfacet
+  facet normal -0.587712 0.80907 0
+    outer loop
+      vertex 17.197 -7.10823 5
+      vertex 17.4 -6.96077 2
+      vertex 17.197 -7.10823 2
+    endloop
+  endfacet
+  facet normal -0.207906 0.978149 0
+    outer loop
+      vertex 17.8746 -6.80657 2
+      vertex 17.6292 -6.85873 5
+      vertex 17.8746 -6.80657 5
+    endloop
+  endfacet
+  facet normal -0.207906 0.978149 0
+    outer loop
+      vertex 17.6292 -6.85873 5
+      vertex 17.8746 -6.80657 2
+      vertex 17.6292 -6.85873 2
+    endloop
+  endfacet
+  facet normal 0.865913 -0.500194 0
+    outer loop
+      vertex 18.9708 -8.70534 5
+      vertex 19.0963 -8.48808 2
+      vertex 19.0963 -8.48808 5
+    endloop
+  endfacet
+  facet normal 0.865913 -0.500194 0
+    outer loop
+      vertex 19.0963 -8.48808 2
+      vertex 18.9708 -8.70534 5
+      vertex 18.9708 -8.70534 2
+    endloop
+  endfacet
+  facet normal 0.865913 0.500194 0
+    outer loop
+      vertex 19.0963 -7.51192 5
+      vertex 18.9708 -7.29466 2
+      vertex 18.9708 -7.29466 5
+    endloop
+  endfacet
+  facet normal 0.865913 0.500194 0
+    outer loop
+      vertex 18.9708 -7.29466 2
+      vertex 19.0963 -7.51192 5
+      vertex 19.0963 -7.51192 2
+    endloop
+  endfacet
+  facet normal 0.951083 0.308936 0
+    outer loop
+      vertex 19.1738 -7.75051 5
+      vertex 19.0963 -7.51192 2
+      vertex 19.0963 -7.51192 5
+    endloop
+  endfacet
+  facet normal 0.951083 0.308936 0
+    outer loop
+      vertex 19.0963 -7.51192 2
+      vertex 19.1738 -7.75051 5
+      vertex 19.1738 -7.75051 2
+    endloop
+  endfacet
+  facet normal 0.743268 0.668993 0
+    outer loop
+      vertex 18.9708 -7.29466 5
+      vertex 18.803 -7.10823 2
+      vertex 18.803 -7.10823 5
+    endloop
+  endfacet
+  facet normal 0.743268 0.668993 0
+    outer loop
+      vertex 18.803 -7.10823 2
+      vertex 18.9708 -7.29466 5
+      vertex 18.9708 -7.29466 2
+    endloop
+  endfacet
+  facet normal 0.207906 0.978149 -0
+    outer loop
+      vertex 18.3708 -6.85873 2
+      vertex 18.1254 -6.80657 5
+      vertex 18.3708 -6.85873 5
+    endloop
+  endfacet
+  facet normal 0.207906 0.978149 0
+    outer loop
+      vertex 18.1254 -6.80657 5
+      vertex 18.3708 -6.85873 2
+      vertex 18.1254 -6.80657 2
+    endloop
+  endfacet
+  facet normal -0.865913 0.500194 0
+    outer loop
+      vertex 16.9037 -7.51192 2
+      vertex 17.0292 -7.29466 5
+      vertex 17.0292 -7.29466 2
+    endloop
+  endfacet
+  facet normal -0.865913 0.500194 0
+    outer loop
+      vertex 17.0292 -7.29466 5
+      vertex 16.9037 -7.51192 2
+      vertex 16.9037 -7.51192 5
+    endloop
+  endfacet
+  facet normal -0.743268 0.668993 0
+    outer loop
+      vertex 17.0292 -7.29466 2
+      vertex 17.197 -7.10823 5
+      vertex 17.197 -7.10823 2
+    endloop
+  endfacet
+  facet normal -0.743268 0.668993 0
+    outer loop
+      vertex 17.197 -7.10823 5
+      vertex 17.0292 -7.29466 2
+      vertex 17.0292 -7.29466 5
+    endloop
+  endfacet
+  facet normal -0.951083 0.308936 0
+    outer loop
+      vertex 16.8262 -7.75051 2
+      vertex 16.9037 -7.51192 5
+      vertex 16.9037 -7.51192 2
+    endloop
+  endfacet
+  facet normal -0.951083 0.308936 0
+    outer loop
+      vertex 16.9037 -7.51192 5
+      vertex 16.8262 -7.75051 2
+      vertex 16.8262 -7.75051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.1738 -7.75051 5
+      vertex 19.1738 -8.24949 5
+      vertex 19.2 -8 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0963 -7.51192 5
+      vertex 19.1738 -8.24949 5
+      vertex 19.1738 -7.75051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0963 -7.51192 5
+      vertex 19.0963 -8.48808 5
+      vertex 19.1738 -8.24949 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9708 -7.29466 5
+      vertex 19.0963 -8.48808 5
+      vertex 19.0963 -7.51192 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9708 -7.29466 5
+      vertex 18.9708 -8.70534 5
+      vertex 19.0963 -8.48808 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.803 -7.10823 5
+      vertex 18.9708 -8.70534 5
+      vertex 18.9708 -7.29466 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.803 -7.10823 5
+      vertex 18.803 -8.89177 5
+      vertex 18.9708 -8.70534 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6 -6.96077 5
+      vertex 18.803 -8.89177 5
+      vertex 18.803 -7.10823 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6 -6.96077 5
+      vertex 18.6 -9.03923 5
+      vertex 18.803 -8.89177 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3708 -6.85873 5
+      vertex 18.6 -9.03923 5
+      vertex 18.6 -6.96077 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3708 -6.85873 5
+      vertex 18.3708 -9.14127 5
+      vertex 18.6 -9.03923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.1254 -6.80657 5
+      vertex 18.3708 -9.14127 5
+      vertex 18.3708 -6.85873 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.1254 -6.80657 5
+      vertex 18.1254 -9.19343 5
+      vertex 18.3708 -9.14127 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.8746 -6.80657 5
+      vertex 18.1254 -9.19343 5
+      vertex 18.1254 -6.80657 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8746 -6.80657 5
+      vertex 17.8746 -9.19343 5
+      vertex 18.1254 -9.19343 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.6292 -6.85873 5
+      vertex 17.8746 -9.19343 5
+      vertex 17.8746 -6.80657 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6292 -6.85873 5
+      vertex 17.6292 -9.14127 5
+      vertex 17.8746 -9.19343 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.4 -6.96077 5
+      vertex 17.6292 -9.14127 5
+      vertex 17.6292 -6.85873 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4 -6.96077 5
+      vertex 17.4 -9.03923 5
+      vertex 17.6292 -9.14127 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.197 -7.10823 5
+      vertex 17.4 -9.03923 5
+      vertex 17.4 -6.96077 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.197 -7.10823 5
+      vertex 17.197 -8.89177 5
+      vertex 17.4 -9.03923 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.0292 -7.29466 5
+      vertex 17.197 -8.89177 5
+      vertex 17.197 -7.10823 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0292 -7.29466 5
+      vertex 17.0292 -8.70534 5
+      vertex 17.197 -8.89177 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.9037 -7.51192 5
+      vertex 17.0292 -8.70534 5
+      vertex 17.0292 -7.29466 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9037 -7.51192 5
+      vertex 16.9037 -8.48808 5
+      vertex 17.0292 -8.70534 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.8262 -7.75051 5
+      vertex 16.9037 -8.48808 5
+      vertex 16.9037 -7.51192 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.8262 -7.75051 5
+      vertex 16.8262 -8.24949 5
+      vertex 16.9037 -8.48808 5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 16.8262 -8.24949 5
+      vertex 16.8262 -7.75051 5
+      vertex 16.8 -8 5
+    endloop
+  endfacet
+  facet normal -0.406715 0.913555 0
+    outer loop
+      vertex 17.6292 -6.85873 2
+      vertex 17.4 -6.96077 5
+      vertex 17.6292 -6.85873 5
+    endloop
+  endfacet
+  facet normal -0.406715 0.913555 0
+    outer loop
+      vertex 17.4 -6.96077 5
+      vertex 17.6292 -6.85873 2
+      vertex 17.4 -6.96077 2
+    endloop
+  endfacet
+  facet normal 0.994531 -0.10444 0
+    outer loop
+      vertex 19.1738 -8.24949 5
+      vertex 19.2 -8 2
+      vertex 19.2 -8 5
+    endloop
+  endfacet
+  facet normal 0.994531 -0.10444 0
+    outer loop
+      vertex 19.2 -8 2
+      vertex 19.1738 -8.24949 5
+      vertex 19.1738 -8.24949 2
+    endloop
+  endfacet
+  facet normal 0.207906 -0.978149 0
+    outer loop
+      vertex 18.1254 -9.19343 2
+      vertex 18.3708 -9.14127 5
+      vertex 18.1254 -9.19343 5
+    endloop
+  endfacet
+  facet normal 0.207906 -0.978149 0
+    outer loop
+      vertex 18.3708 -9.14127 5
+      vertex 18.1254 -9.19343 2
+      vertex 18.3708 -9.14127 2
+    endloop
+  endfacet
+  facet normal 0.587712 -0.80907 0
+    outer loop
+      vertex 18.6 -9.03923 2
+      vertex 18.803 -8.89177 5
+      vertex 18.6 -9.03923 5
+    endloop
+  endfacet
+  facet normal 0.587712 -0.80907 0
+    outer loop
+      vertex 18.803 -8.89177 5
+      vertex 18.6 -9.03923 2
+      vertex 18.803 -8.89177 2
+    endloop
+  endfacet
+  facet normal 0.743268 -0.668993 0
+    outer loop
+      vertex 18.803 -8.89177 5
+      vertex 18.9708 -8.70534 2
+      vertex 18.9708 -8.70534 5
+    endloop
+  endfacet
+  facet normal 0.743268 -0.668993 0
+    outer loop
+      vertex 18.9708 -8.70534 2
+      vertex 18.803 -8.89177 5
+      vertex 18.803 -8.89177 2
+    endloop
+  endfacet
+  facet normal 0.951083 -0.308936 0
+    outer loop
+      vertex 19.0963 -8.48808 5
+      vertex 19.1738 -8.24949 2
+      vertex 19.1738 -8.24949 5
+    endloop
+  endfacet
+  facet normal 0.951083 -0.308936 0
+    outer loop
+      vertex 19.1738 -8.24949 2
+      vertex 19.0963 -8.48808 5
+      vertex 19.0963 -8.48808 2
+    endloop
+  endfacet
+  facet normal -0.587712 -0.80907 0
+    outer loop
+      vertex 17.197 -8.89177 2
+      vertex 17.4 -9.03923 5
+      vertex 17.197 -8.89177 5
+    endloop
+  endfacet
+  facet normal -0.587712 -0.80907 -0
+    outer loop
+      vertex 17.4 -9.03923 5
+      vertex 17.197 -8.89177 2
+      vertex 17.4 -9.03923 2
+    endloop
+  endfacet
+  facet normal -0.865913 -0.500194 0
+    outer loop
+      vertex 17.0292 -8.70534 2
+      vertex 16.9037 -8.48808 5
+      vertex 16.9037 -8.48808 2
+    endloop
+  endfacet
+  facet normal -0.865913 -0.500194 0
+    outer loop
+      vertex 16.9037 -8.48808 5
+      vertex 17.0292 -8.70534 2
+      vertex 17.0292 -8.70534 5
+    endloop
+  endfacet
+  facet normal -0.743268 -0.668993 0
+    outer loop
+      vertex 17.197 -8.89177 2
+      vertex 17.0292 -8.70534 5
+      vertex 17.0292 -8.70534 2
+    endloop
+  endfacet
+  facet normal -0.743268 -0.668993 0
+    outer loop
+      vertex 17.0292 -8.70534 5
+      vertex 17.197 -8.89177 2
+      vertex 17.197 -8.89177 5
+    endloop
+  endfacet
+  facet normal -0.994531 -0.10444 0
+    outer loop
+      vertex 16.8262 -8.24949 2
+      vertex 16.8 -8 5
+      vertex 16.8 -8 2
+    endloop
+  endfacet
+  facet normal -0.994531 -0.10444 0
+    outer loop
+      vertex 16.8 -8 5
+      vertex 16.8262 -8.24949 2
+      vertex 16.8262 -8.24949 5
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex 18.3708 -9.14127 2
+      vertex 18.6 -9.03923 5
+      vertex 18.3708 -9.14127 5
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex 18.6 -9.03923 5
+      vertex 18.3708 -9.14127 2
+      vertex 18.6 -9.03923 2
+    endloop
+  endfacet
+  facet normal -0.207906 -0.978149 0
+    outer loop
+      vertex 17.6292 -9.14127 2
+      vertex 17.8746 -9.19343 5
+      vertex 17.6292 -9.14127 5
+    endloop
+  endfacet
+  facet normal -0.207906 -0.978149 -0
+    outer loop
+      vertex 17.8746 -9.19343 5
+      vertex 17.6292 -9.14127 2
+      vertex 17.8746 -9.19343 2
+    endloop
+  endfacet
+  facet normal -0.951083 -0.308936 0
+    outer loop
+      vertex 16.9037 -8.48808 2
+      vertex 16.8262 -8.24949 5
+      vertex 16.8262 -8.24949 2
+    endloop
+  endfacet
+  facet normal -0.951083 -0.308936 0
+    outer loop
+      vertex 16.8262 -8.24949 5
+      vertex 16.9037 -8.48808 2
+      vertex 16.9037 -8.48808 5
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 0
+    outer loop
+      vertex 17.4 -9.03923 2
+      vertex 17.6292 -9.14127 5
+      vertex 17.4 -9.03923 5
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 -0
+    outer loop
+      vertex 17.6292 -9.14127 5
+      vertex 17.4 -9.03923 2
+      vertex 17.6292 -9.14127 2
+    endloop
+  endfacet
+  facet normal 0.865913 0.500194 0
+    outer loop
+      vertex -16.9037 8.48808 5
+      vertex -17.0292 8.70534 2
+      vertex -17.0292 8.70534 5
+    endloop
+  endfacet
+  facet normal 0.865913 0.500194 0
+    outer loop
+      vertex -17.0292 8.70534 2
+      vertex -16.9037 8.48808 5
+      vertex -16.9037 8.48808 2
+    endloop
+  endfacet
+  facet normal 0.994531 0.10444 0
+    outer loop
+      vertex -16.8 8 5
+      vertex -16.8262 8.24949 2
+      vertex -16.8262 8.24949 5
+    endloop
+  endfacet
+  facet normal 0.994531 0.10444 0
+    outer loop
+      vertex -16.8262 8.24949 2
+      vertex -16.8 8 5
+      vertex -16.8 8 2
+    endloop
+  endfacet
+  facet normal -0.994531 -0.10444 0
+    outer loop
+      vertex -19.1738 7.75051 2
+      vertex -19.2 8 5
+      vertex -19.2 8 2
+    endloop
+  endfacet
+  facet normal -0.994531 -0.10444 0
+    outer loop
+      vertex -19.2 8 5
+      vertex -19.1738 7.75051 2
+      vertex -19.1738 7.75051 5
+    endloop
+  endfacet
+  facet normal 0.743268 0.668993 0
+    outer loop
+      vertex -17.0292 8.70534 5
+      vertex -17.197 8.89177 2
+      vertex -17.197 8.89177 5
+    endloop
+  endfacet
+  facet normal 0.743268 0.668993 0
+    outer loop
+      vertex -17.197 8.89177 2
+      vertex -17.0292 8.70534 5
+      vertex -17.0292 8.70534 2
+    endloop
+  endfacet
+  facet normal 0.207906 0.978149 -0
+    outer loop
+      vertex -17.6292 9.14127 2
+      vertex -17.8746 9.19343 5
+      vertex -17.6292 9.14127 5
+    endloop
+  endfacet
+  facet normal 0.207906 0.978149 0
+    outer loop
+      vertex -17.8746 9.19343 5
+      vertex -17.6292 9.14127 2
+      vertex -17.8746 9.19343 2
+    endloop
+  endfacet
+  facet normal -0.587712 0.80907 0
+    outer loop
+      vertex -18.6 9.03923 2
+      vertex -18.803 8.89177 5
+      vertex -18.6 9.03923 5
+    endloop
+  endfacet
+  facet normal -0.587712 0.80907 0
+    outer loop
+      vertex -18.803 8.89177 5
+      vertex -18.6 9.03923 2
+      vertex -18.803 8.89177 2
+    endloop
+  endfacet
+  facet normal -0.994531 0.10444 0
+    outer loop
+      vertex -19.2 8 2
+      vertex -19.1738 8.24949 5
+      vertex -19.1738 8.24949 2
+    endloop
+  endfacet
+  facet normal -0.994531 0.10444 0
+    outer loop
+      vertex -19.1738 8.24949 5
+      vertex -19.2 8 2
+      vertex -19.2 8 5
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex -17.6292 6.85873 2
+      vertex -17.4 6.96077 5
+      vertex -17.6292 6.85873 5
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex -17.4 6.96077 5
+      vertex -17.6292 6.85873 2
+      vertex -17.4 6.96077 2
+    endloop
+  endfacet
+  facet normal 0.587712 0.80907 -0
+    outer loop
+      vertex -17.197 8.89177 2
+      vertex -17.4 9.03923 5
+      vertex -17.197 8.89177 5
+    endloop
+  endfacet
+  facet normal 0.587712 0.80907 0
+    outer loop
+      vertex -17.4 9.03923 5
+      vertex -17.197 8.89177 2
+      vertex -17.4 9.03923 2
+    endloop
+  endfacet
+  facet normal -0.207906 0.978149 0
+    outer loop
+      vertex -18.1254 9.19343 2
+      vertex -18.3708 9.14127 5
+      vertex -18.1254 9.19343 5
+    endloop
+  endfacet
+  facet normal -0.207906 0.978149 0
+    outer loop
+      vertex -18.3708 9.14127 5
+      vertex -18.1254 9.19343 2
+      vertex -18.3708 9.14127 2
+    endloop
+  endfacet
+  facet normal 0.406715 0.913555 -0
+    outer loop
+      vertex -17.4 9.03923 2
+      vertex -17.6292 9.14127 5
+      vertex -17.4 9.03923 5
+    endloop
+  endfacet
+  facet normal 0.406715 0.913555 0
+    outer loop
+      vertex -17.6292 9.14127 5
+      vertex -17.4 9.03923 2
+      vertex -17.6292 9.14127 2
+    endloop
+  endfacet
+  facet normal -0.951083 0.308936 0
+    outer loop
+      vertex -19.1738 8.24949 2
+      vertex -19.0963 8.48808 5
+      vertex -19.0963 8.48808 2
+    endloop
+  endfacet
+  facet normal -0.951083 0.308936 0
+    outer loop
+      vertex -19.0963 8.48808 5
+      vertex -19.1738 8.24949 2
+      vertex -19.1738 8.24949 5
+    endloop
+  endfacet
+  facet normal -0.743268 0.668993 0
+    outer loop
+      vertex -18.9708 8.70534 2
+      vertex -18.803 8.89177 5
+      vertex -18.803 8.89177 2
+    endloop
+  endfacet
+  facet normal -0.743268 0.668993 0
+    outer loop
+      vertex -18.803 8.89177 5
+      vertex -18.9708 8.70534 2
+      vertex -18.9708 8.70534 5
+    endloop
+  endfacet
+  facet normal -0.406715 0.913555 0
+    outer loop
+      vertex -18.3708 9.14127 2
+      vertex -18.6 9.03923 5
+      vertex -18.3708 9.14127 5
+    endloop
+  endfacet
+  facet normal -0.406715 0.913555 0
+    outer loop
+      vertex -18.6 9.03923 5
+      vertex -18.3708 9.14127 2
+      vertex -18.6 9.03923 2
+    endloop
+  endfacet
+  facet normal -0.865913 0.500194 0
+    outer loop
+      vertex -19.0963 8.48808 2
+      vertex -18.9708 8.70534 5
+      vertex -18.9708 8.70534 2
+    endloop
+  endfacet
+  facet normal -0.865913 0.500194 0
+    outer loop
+      vertex -18.9708 8.70534 5
+      vertex -19.0963 8.48808 2
+      vertex -19.0963 8.48808 5
+    endloop
+  endfacet
+  facet normal 0.951083 -0.308936 0
+    outer loop
+      vertex -16.9037 7.51192 5
+      vertex -16.8262 7.75051 2
+      vertex -16.8262 7.75051 5
+    endloop
+  endfacet
+  facet normal 0.951083 -0.308936 0
+    outer loop
+      vertex -16.8262 7.75051 2
+      vertex -16.9037 7.51192 5
+      vertex -16.9037 7.51192 2
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 0
+    outer loop
+      vertex -18.6 6.96077 2
+      vertex -18.3708 6.85873 5
+      vertex -18.6 6.96077 5
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 -0
+    outer loop
+      vertex -18.3708 6.85873 5
+      vertex -18.6 6.96077 2
+      vertex -18.3708 6.85873 2
+    endloop
+  endfacet
+  facet normal -0.743268 -0.668993 0
+    outer loop
+      vertex -18.803 7.10823 2
+      vertex -18.9708 7.29466 5
+      vertex -18.9708 7.29466 2
+    endloop
+  endfacet
+  facet normal -0.743268 -0.668993 0
+    outer loop
+      vertex -18.9708 7.29466 5
+      vertex -18.803 7.10823 2
+      vertex -18.803 7.10823 5
+    endloop
+  endfacet
+  facet normal 0.743268 -0.668993 0
+    outer loop
+      vertex -17.197 7.10823 5
+      vertex -17.0292 7.29466 2
+      vertex -17.0292 7.29466 5
+    endloop
+  endfacet
+  facet normal 0.743268 -0.668993 0
+    outer loop
+      vertex -17.0292 7.29466 2
+      vertex -17.197 7.10823 5
+      vertex -17.197 7.10823 2
+    endloop
+  endfacet
+  facet normal 0.994531 -0.10444 0
+    outer loop
+      vertex -16.8262 7.75051 5
+      vertex -16.8 8 2
+      vertex -16.8 8 5
+    endloop
+  endfacet
+  facet normal 0.994531 -0.10444 0
+    outer loop
+      vertex -16.8 8 2
+      vertex -16.8262 7.75051 5
+      vertex -16.8262 7.75051 2
+    endloop
+  endfacet
+  facet normal 0.951083 0.308936 0
+    outer loop
+      vertex -16.8262 8.24949 5
+      vertex -16.9037 8.48808 2
+      vertex -16.9037 8.48808 5
+    endloop
+  endfacet
+  facet normal 0.951083 0.308936 0
+    outer loop
+      vertex -16.9037 8.48808 2
+      vertex -16.8262 8.24949 5
+      vertex -16.8262 8.24949 2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.8746 9.19343 2
+      vertex -18.1254 9.19343 5
+      vertex -17.8746 9.19343 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.1254 9.19343 5
+      vertex -17.8746 9.19343 2
+      vertex -18.1254 9.19343 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.8262 8.24949 5
+      vertex -16.8262 7.75051 5
+      vertex -16.8 8 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9037 8.48808 5
+      vertex -16.8262 7.75051 5
+      vertex -16.8262 8.24949 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9037 8.48808 5
+      vertex -16.9037 7.51192 5
+      vertex -16.8262 7.75051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.0292 8.70534 5
+      vertex -16.9037 7.51192 5
+      vertex -16.9037 8.48808 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.0292 8.70534 5
+      vertex -17.0292 7.29466 5
+      vertex -16.9037 7.51192 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.197 8.89177 5
+      vertex -17.0292 7.29466 5
+      vertex -17.0292 8.70534 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.197 8.89177 5
+      vertex -17.197 7.10823 5
+      vertex -17.0292 7.29466 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4 9.03923 5
+      vertex -17.197 7.10823 5
+      vertex -17.197 8.89177 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4 9.03923 5
+      vertex -17.4 6.96077 5
+      vertex -17.197 7.10823 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6292 9.14127 5
+      vertex -17.4 6.96077 5
+      vertex -17.4 9.03923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6292 9.14127 5
+      vertex -17.6292 6.85873 5
+      vertex -17.4 6.96077 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8746 9.19343 5
+      vertex -17.6292 6.85873 5
+      vertex -17.6292 9.14127 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8746 9.19343 5
+      vertex -17.8746 6.80657 5
+      vertex -17.6292 6.85873 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.1254 9.19343 5
+      vertex -17.8746 6.80657 5
+      vertex -17.8746 9.19343 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.1254 9.19343 5
+      vertex -18.1254 6.80657 5
+      vertex -17.8746 6.80657 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.3708 9.14127 5
+      vertex -18.1254 6.80657 5
+      vertex -18.1254 9.19343 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3708 9.14127 5
+      vertex -18.3708 6.85873 5
+      vertex -18.1254 6.80657 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.6 9.03923 5
+      vertex -18.3708 6.85873 5
+      vertex -18.3708 9.14127 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6 9.03923 5
+      vertex -18.6 6.96077 5
+      vertex -18.3708 6.85873 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.803 8.89177 5
+      vertex -18.6 6.96077 5
+      vertex -18.6 9.03923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.803 8.89177 5
+      vertex -18.803 7.10823 5
+      vertex -18.6 6.96077 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.9708 8.70534 5
+      vertex -18.803 7.10823 5
+      vertex -18.803 8.89177 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9708 8.70534 5
+      vertex -18.9708 7.29466 5
+      vertex -18.803 7.10823 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.0963 8.48808 5
+      vertex -18.9708 7.29466 5
+      vertex -18.9708 8.70534 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0963 8.48808 5
+      vertex -19.0963 7.51192 5
+      vertex -18.9708 7.29466 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.1738 8.24949 5
+      vertex -19.0963 7.51192 5
+      vertex -19.0963 8.48808 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.1738 8.24949 5
+      vertex -19.1738 7.75051 5
+      vertex -19.0963 7.51192 5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -19.1738 7.75051 5
+      vertex -19.1738 8.24949 5
+      vertex -19.2 8 5
+    endloop
+  endfacet
+  facet normal 0.207906 -0.978149 0
+    outer loop
+      vertex -17.8746 6.80657 2
+      vertex -17.6292 6.85873 5
+      vertex -17.8746 6.80657 5
+    endloop
+  endfacet
+  facet normal 0.207906 -0.978149 0
+    outer loop
+      vertex -17.6292 6.85873 5
+      vertex -17.8746 6.80657 2
+      vertex -17.6292 6.85873 2
+    endloop
+  endfacet
+  facet normal -0.587712 -0.80907 0
+    outer loop
+      vertex -18.803 7.10823 2
+      vertex -18.6 6.96077 5
+      vertex -18.803 7.10823 5
+    endloop
+  endfacet
+  facet normal -0.587712 -0.80907 -0
+    outer loop
+      vertex -18.6 6.96077 5
+      vertex -18.803 7.10823 2
+      vertex -18.6 6.96077 2
+    endloop
+  endfacet
+  facet normal 0.587712 -0.80907 0
+    outer loop
+      vertex -17.4 6.96077 2
+      vertex -17.197 7.10823 5
+      vertex -17.4 6.96077 5
+    endloop
+  endfacet
+  facet normal 0.587712 -0.80907 0
+    outer loop
+      vertex -17.197 7.10823 5
+      vertex -17.4 6.96077 2
+      vertex -17.197 7.10823 2
+    endloop
+  endfacet
+  facet normal -0.207906 -0.978149 0
+    outer loop
+      vertex -18.3708 6.85873 2
+      vertex -18.1254 6.80657 5
+      vertex -18.3708 6.85873 5
+    endloop
+  endfacet
+  facet normal -0.207906 -0.978149 -0
+    outer loop
+      vertex -18.1254 6.80657 5
+      vertex -18.3708 6.85873 2
+      vertex -18.1254 6.80657 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -18.1254 6.80657 2
+      vertex -17.8746 6.80657 5
+      vertex -18.1254 6.80657 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -17.8746 6.80657 5
+      vertex -18.1254 6.80657 2
+      vertex -17.8746 6.80657 2
+    endloop
+  endfacet
+  facet normal -0.865913 -0.500194 0
+    outer loop
+      vertex -18.9708 7.29466 2
+      vertex -19.0963 7.51192 5
+      vertex -19.0963 7.51192 2
+    endloop
+  endfacet
+  facet normal -0.865913 -0.500194 0
+    outer loop
+      vertex -19.0963 7.51192 5
+      vertex -18.9708 7.29466 2
+      vertex -18.9708 7.29466 5
+    endloop
+  endfacet
+  facet normal -0.951083 -0.308936 0
+    outer loop
+      vertex -19.0963 7.51192 2
+      vertex -19.1738 7.75051 5
+      vertex -19.1738 7.75051 2
+    endloop
+  endfacet
+  facet normal -0.951083 -0.308936 0
+    outer loop
+      vertex -19.1738 7.75051 5
+      vertex -19.0963 7.51192 2
+      vertex -19.0963 7.51192 5
+    endloop
+  endfacet
+  facet normal 0.865913 -0.500194 0
+    outer loop
+      vertex -17.0292 7.29466 5
+      vertex -16.9037 7.51192 2
+      vertex -16.9037 7.51192 5
+    endloop
+  endfacet
+  facet normal 0.865913 -0.500194 0
+    outer loop
+      vertex -16.9037 7.51192 2
+      vertex -17.0292 7.29466 5
+      vertex -17.0292 7.29466 2
+    endloop
+  endfacet
+  facet normal 0.994531 0.10444 0
+    outer loop
+      vertex -16.8 -8 5
+      vertex -16.8262 -7.75051 2
+      vertex -16.8262 -7.75051 5
+    endloop
+  endfacet
+  facet normal 0.994531 0.10444 0
+    outer loop
+      vertex -16.8262 -7.75051 2
+      vertex -16.8 -8 5
+      vertex -16.8 -8 2
+    endloop
+  endfacet
+  facet normal -0.994531 0.10444 0
+    outer loop
+      vertex -19.2 -8 2
+      vertex -19.1738 -7.75051 5
+      vertex -19.1738 -7.75051 2
+    endloop
+  endfacet
+  facet normal -0.994531 0.10444 0
+    outer loop
+      vertex -19.1738 -7.75051 5
+      vertex -19.2 -8 2
+      vertex -19.2 -8 5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.8746 -6.80657 2
+      vertex -18.1254 -6.80657 5
+      vertex -17.8746 -6.80657 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.1254 -6.80657 5
+      vertex -17.8746 -6.80657 2
+      vertex -18.1254 -6.80657 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -18.1254 -9.19343 2
+      vertex -17.8746 -9.19343 5
+      vertex -18.1254 -9.19343 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -17.8746 -9.19343 5
+      vertex -18.1254 -9.19343 2
+      vertex -17.8746 -9.19343 2
+    endloop
+  endfacet
+  facet normal 0.587712 0.80907 -0
+    outer loop
+      vertex -17.197 -7.10823 2
+      vertex -17.4 -6.96077 5
+      vertex -17.197 -7.10823 5
+    endloop
+  endfacet
+  facet normal 0.587712 0.80907 0
+    outer loop
+      vertex -17.4 -6.96077 5
+      vertex -17.197 -7.10823 2
+      vertex -17.4 -6.96077 2
+    endloop
+  endfacet
+  facet normal 0.406715 0.913555 -0
+    outer loop
+      vertex -17.4 -6.96077 2
+      vertex -17.6292 -6.85873 5
+      vertex -17.4 -6.96077 5
+    endloop
+  endfacet
+  facet normal 0.406715 0.913555 0
+    outer loop
+      vertex -17.6292 -6.85873 5
+      vertex -17.4 -6.96077 2
+      vertex -17.6292 -6.85873 2
+    endloop
+  endfacet
+  facet normal -0.587712 0.80907 0
+    outer loop
+      vertex -18.6 -6.96077 2
+      vertex -18.803 -7.10823 5
+      vertex -18.6 -6.96077 5
+    endloop
+  endfacet
+  facet normal -0.587712 0.80907 0
+    outer loop
+      vertex -18.803 -7.10823 5
+      vertex -18.6 -6.96077 2
+      vertex -18.803 -7.10823 2
+    endloop
+  endfacet
+  facet normal -0.207906 0.978149 0
+    outer loop
+      vertex -18.1254 -6.80657 2
+      vertex -18.3708 -6.85873 5
+      vertex -18.1254 -6.80657 5
+    endloop
+  endfacet
+  facet normal -0.207906 0.978149 0
+    outer loop
+      vertex -18.3708 -6.85873 5
+      vertex -18.1254 -6.80657 2
+      vertex -18.3708 -6.85873 2
+    endloop
+  endfacet
+  facet normal 0.865913 -0.500194 0
+    outer loop
+      vertex -17.0292 -8.70534 5
+      vertex -16.9037 -8.48808 2
+      vertex -16.9037 -8.48808 5
+    endloop
+  endfacet
+  facet normal 0.865913 -0.500194 0
+    outer loop
+      vertex -16.9037 -8.48808 2
+      vertex -17.0292 -8.70534 5
+      vertex -17.0292 -8.70534 2
+    endloop
+  endfacet
+  facet normal 0.865913 0.500194 0
+    outer loop
+      vertex -16.9037 -7.51192 5
+      vertex -17.0292 -7.29466 2
+      vertex -17.0292 -7.29466 5
+    endloop
+  endfacet
+  facet normal 0.865913 0.500194 0
+    outer loop
+      vertex -17.0292 -7.29466 2
+      vertex -16.9037 -7.51192 5
+      vertex -16.9037 -7.51192 2
+    endloop
+  endfacet
+  facet normal 0.951083 0.308936 0
+    outer loop
+      vertex -16.8262 -7.75051 5
+      vertex -16.9037 -7.51192 2
+      vertex -16.9037 -7.51192 5
+    endloop
+  endfacet
+  facet normal 0.951083 0.308936 0
+    outer loop
+      vertex -16.9037 -7.51192 2
+      vertex -16.8262 -7.75051 5
+      vertex -16.8262 -7.75051 2
+    endloop
+  endfacet
+  facet normal 0.743268 0.668993 0
+    outer loop
+      vertex -17.0292 -7.29466 5
+      vertex -17.197 -7.10823 2
+      vertex -17.197 -7.10823 5
+    endloop
+  endfacet
+  facet normal 0.743268 0.668993 0
+    outer loop
+      vertex -17.197 -7.10823 2
+      vertex -17.0292 -7.29466 5
+      vertex -17.0292 -7.29466 2
+    endloop
+  endfacet
+  facet normal 0.207906 0.978149 -0
+    outer loop
+      vertex -17.6292 -6.85873 2
+      vertex -17.8746 -6.80657 5
+      vertex -17.6292 -6.85873 5
+    endloop
+  endfacet
+  facet normal 0.207906 0.978149 0
+    outer loop
+      vertex -17.8746 -6.80657 5
+      vertex -17.6292 -6.85873 2
+      vertex -17.8746 -6.80657 2
+    endloop
+  endfacet
+  facet normal -0.865913 0.500194 0
+    outer loop
+      vertex -19.0963 -7.51192 2
+      vertex -18.9708 -7.29466 5
+      vertex -18.9708 -7.29466 2
+    endloop
+  endfacet
+  facet normal -0.865913 0.500194 0
+    outer loop
+      vertex -18.9708 -7.29466 5
+      vertex -19.0963 -7.51192 2
+      vertex -19.0963 -7.51192 5
+    endloop
+  endfacet
+  facet normal -0.743268 0.668993 0
+    outer loop
+      vertex -18.9708 -7.29466 2
+      vertex -18.803 -7.10823 5
+      vertex -18.803 -7.10823 2
+    endloop
+  endfacet
+  facet normal -0.743268 0.668993 0
+    outer loop
+      vertex -18.803 -7.10823 5
+      vertex -18.9708 -7.29466 2
+      vertex -18.9708 -7.29466 5
+    endloop
+  endfacet
+  facet normal -0.951083 0.308936 0
+    outer loop
+      vertex -19.1738 -7.75051 2
+      vertex -19.0963 -7.51192 5
+      vertex -19.0963 -7.51192 2
+    endloop
+  endfacet
+  facet normal -0.951083 0.308936 0
+    outer loop
+      vertex -19.0963 -7.51192 5
+      vertex -19.1738 -7.75051 2
+      vertex -19.1738 -7.75051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.8262 -7.75051 5
+      vertex -16.8262 -8.24949 5
+      vertex -16.8 -8 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9037 -7.51192 5
+      vertex -16.8262 -8.24949 5
+      vertex -16.8262 -7.75051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9037 -7.51192 5
+      vertex -16.9037 -8.48808 5
+      vertex -16.8262 -8.24949 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.0292 -7.29466 5
+      vertex -16.9037 -8.48808 5
+      vertex -16.9037 -7.51192 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.0292 -7.29466 5
+      vertex -17.0292 -8.70534 5
+      vertex -16.9037 -8.48808 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.197 -7.10823 5
+      vertex -17.0292 -8.70534 5
+      vertex -17.0292 -7.29466 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.197 -7.10823 5
+      vertex -17.197 -8.89177 5
+      vertex -17.0292 -8.70534 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4 -6.96077 5
+      vertex -17.197 -8.89177 5
+      vertex -17.197 -7.10823 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4 -6.96077 5
+      vertex -17.4 -9.03923 5
+      vertex -17.197 -8.89177 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6292 -6.85873 5
+      vertex -17.4 -9.03923 5
+      vertex -17.4 -6.96077 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6292 -6.85873 5
+      vertex -17.6292 -9.14127 5
+      vertex -17.4 -9.03923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8746 -6.80657 5
+      vertex -17.6292 -9.14127 5
+      vertex -17.6292 -6.85873 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8746 -6.80657 5
+      vertex -17.8746 -9.19343 5
+      vertex -17.6292 -9.14127 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.1254 -6.80657 5
+      vertex -17.8746 -9.19343 5
+      vertex -17.8746 -6.80657 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.1254 -6.80657 5
+      vertex -18.1254 -9.19343 5
+      vertex -17.8746 -9.19343 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.3708 -6.85873 5
+      vertex -18.1254 -9.19343 5
+      vertex -18.1254 -6.80657 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3708 -6.85873 5
+      vertex -18.3708 -9.14127 5
+      vertex -18.1254 -9.19343 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.6 -6.96077 5
+      vertex -18.3708 -9.14127 5
+      vertex -18.3708 -6.85873 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6 -6.96077 5
+      vertex -18.6 -9.03923 5
+      vertex -18.3708 -9.14127 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.803 -7.10823 5
+      vertex -18.6 -9.03923 5
+      vertex -18.6 -6.96077 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.803 -7.10823 5
+      vertex -18.803 -8.89177 5
+      vertex -18.6 -9.03923 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.9708 -7.29466 5
+      vertex -18.803 -8.89177 5
+      vertex -18.803 -7.10823 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9708 -7.29466 5
+      vertex -18.9708 -8.70534 5
+      vertex -18.803 -8.89177 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.0963 -7.51192 5
+      vertex -18.9708 -8.70534 5
+      vertex -18.9708 -7.29466 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0963 -7.51192 5
+      vertex -19.0963 -8.48808 5
+      vertex -18.9708 -8.70534 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.1738 -7.75051 5
+      vertex -19.0963 -8.48808 5
+      vertex -19.0963 -7.51192 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.1738 -7.75051 5
+      vertex -19.1738 -8.24949 5
+      vertex -19.0963 -8.48808 5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -19.1738 -8.24949 5
+      vertex -19.1738 -7.75051 5
+      vertex -19.2 -8 5
+    endloop
+  endfacet
+  facet normal -0.406715 0.913555 0
+    outer loop
+      vertex -18.3708 -6.85873 2
+      vertex -18.6 -6.96077 5
+      vertex -18.3708 -6.85873 5
+    endloop
+  endfacet
+  facet normal -0.406715 0.913555 0
+    outer loop
+      vertex -18.6 -6.96077 5
+      vertex -18.3708 -6.85873 2
+      vertex -18.6 -6.96077 2
+    endloop
+  endfacet
+  facet normal 0.207906 -0.978149 0
+    outer loop
+      vertex -17.8746 -9.19343 2
+      vertex -17.6292 -9.14127 5
+      vertex -17.8746 -9.19343 5
+    endloop
+  endfacet
+  facet normal 0.207906 -0.978149 0
+    outer loop
+      vertex -17.6292 -9.14127 5
+      vertex -17.8746 -9.19343 2
+      vertex -17.6292 -9.14127 2
+    endloop
+  endfacet
+  facet normal 0.587712 -0.80907 0
+    outer loop
+      vertex -17.4 -9.03923 2
+      vertex -17.197 -8.89177 5
+      vertex -17.4 -9.03923 5
+    endloop
+  endfacet
+  facet normal 0.587712 -0.80907 0
+    outer loop
+      vertex -17.197 -8.89177 5
+      vertex -17.4 -9.03923 2
+      vertex -17.197 -8.89177 2
+    endloop
+  endfacet
+  facet normal 0.743268 -0.668993 0
+    outer loop
+      vertex -17.197 -8.89177 5
+      vertex -17.0292 -8.70534 2
+      vertex -17.0292 -8.70534 5
+    endloop
+  endfacet
+  facet normal 0.743268 -0.668993 0
+    outer loop
+      vertex -17.0292 -8.70534 2
+      vertex -17.197 -8.89177 5
+      vertex -17.197 -8.89177 2
+    endloop
+  endfacet
+  facet normal 0.951083 -0.308936 0
+    outer loop
+      vertex -16.9037 -8.48808 5
+      vertex -16.8262 -8.24949 2
+      vertex -16.8262 -8.24949 5
+    endloop
+  endfacet
+  facet normal 0.951083 -0.308936 0
+    outer loop
+      vertex -16.8262 -8.24949 2
+      vertex -16.9037 -8.48808 5
+      vertex -16.9037 -8.48808 2
+    endloop
+  endfacet
+  facet normal 0.994531 -0.10444 0
+    outer loop
+      vertex -16.8262 -8.24949 5
+      vertex -16.8 -8 2
+      vertex -16.8 -8 5
+    endloop
+  endfacet
+  facet normal 0.994531 -0.10444 0
+    outer loop
+      vertex -16.8 -8 2
+      vertex -16.8262 -8.24949 5
+      vertex -16.8262 -8.24949 2
+    endloop
+  endfacet
+  facet normal -0.587712 -0.80907 0
+    outer loop
+      vertex -18.803 -8.89177 2
+      vertex -18.6 -9.03923 5
+      vertex -18.803 -8.89177 5
+    endloop
+  endfacet
+  facet normal -0.587712 -0.80907 -0
+    outer loop
+      vertex -18.6 -9.03923 5
+      vertex -18.803 -8.89177 2
+      vertex -18.6 -9.03923 2
+    endloop
+  endfacet
+  facet normal -0.865913 -0.500194 0
+    outer loop
+      vertex -18.9708 -8.70534 2
+      vertex -19.0963 -8.48808 5
+      vertex -19.0963 -8.48808 2
+    endloop
+  endfacet
+  facet normal -0.865913 -0.500194 0
+    outer loop
+      vertex -19.0963 -8.48808 5
+      vertex -18.9708 -8.70534 2
+      vertex -18.9708 -8.70534 5
+    endloop
+  endfacet
+  facet normal -0.743268 -0.668993 0
+    outer loop
+      vertex -18.803 -8.89177 2
+      vertex -18.9708 -8.70534 5
+      vertex -18.9708 -8.70534 2
+    endloop
+  endfacet
+  facet normal -0.743268 -0.668993 0
+    outer loop
+      vertex -18.9708 -8.70534 5
+      vertex -18.803 -8.89177 2
+      vertex -18.803 -8.89177 5
+    endloop
+  endfacet
+  facet normal -0.994531 -0.10444 0
+    outer loop
+      vertex -19.1738 -8.24949 2
+      vertex -19.2 -8 5
+      vertex -19.2 -8 2
+    endloop
+  endfacet
+  facet normal -0.994531 -0.10444 0
+    outer loop
+      vertex -19.2 -8 5
+      vertex -19.1738 -8.24949 2
+      vertex -19.1738 -8.24949 5
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex -17.6292 -9.14127 2
+      vertex -17.4 -9.03923 5
+      vertex -17.6292 -9.14127 5
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex -17.4 -9.03923 5
+      vertex -17.6292 -9.14127 2
+      vertex -17.4 -9.03923 2
+    endloop
+  endfacet
+  facet normal -0.207906 -0.978149 0
+    outer loop
+      vertex -18.3708 -9.14127 2
+      vertex -18.1254 -9.19343 5
+      vertex -18.3708 -9.14127 5
+    endloop
+  endfacet
+  facet normal -0.207906 -0.978149 -0
+    outer loop
+      vertex -18.1254 -9.19343 5
+      vertex -18.3708 -9.14127 2
+      vertex -18.1254 -9.19343 2
+    endloop
+  endfacet
+  facet normal -0.951083 -0.308936 0
+    outer loop
+      vertex -19.0963 -8.48808 2
+      vertex -19.1738 -8.24949 5
+      vertex -19.1738 -8.24949 2
+    endloop
+  endfacet
+  facet normal -0.951083 -0.308936 0
+    outer loop
+      vertex -19.1738 -8.24949 5
+      vertex -19.0963 -8.48808 2
+      vertex -19.0963 -8.48808 5
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 0
+    outer loop
+      vertex -18.6 -9.03923 2
+      vertex -18.3708 -9.14127 5
+      vertex -18.6 -9.03923 5
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 -0
+    outer loop
+      vertex -18.3708 -9.14127 5
+      vertex -18.6 -9.03923 2
+      vertex -18.3708 -9.14127 2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -13.5725 11 2
+      vertex -13.5725 12.8 5
+      vertex -13.5725 12.8 2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -13.5725 12.8 5
+      vertex -13.5725 11 2
+      vertex -13.5725 11 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.5725 12.8 5
+      vertex 13.5725 11 5
+      vertex 13.5725 12.8 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 11 5
+      vertex -13.5725 12.8 5
+      vertex -13.5725 11 5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 13.5725 11 5
+      vertex 13.5725 12.8 2
+      vertex 13.5725 12.8 5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 13.5725 12.8 2
+      vertex 13.5725 11 5
+      vertex 13.5725 11 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -13.5725 11 2
+      vertex 13.5725 11 5
+      vertex -13.5725 11 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 13.5725 11 5
+      vertex -13.5725 11 2
+      vertex 13.5725 11 2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -13.5725 -12.8 2
+      vertex -13.5725 -11 5
+      vertex -13.5725 -11 2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -13.5725 -11 5
+      vertex -13.5725 -12.8 2
+      vertex -13.5725 -12.8 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.5725 -11 5
+      vertex 13.5725 -12.8 5
+      vertex 13.5725 -11 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5725 -12.8 5
+      vertex -13.5725 -11 5
+      vertex -13.5725 -12.8 5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 13.5725 -12.8 5
+      vertex 13.5725 -11 2
+      vertex 13.5725 -11 5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 13.5725 -11 2
+      vertex 13.5725 -12.8 5
+      vertex 13.5725 -12.8 2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 13.5725 -11 2
+      vertex -13.5725 -11 5
+      vertex 13.5725 -11 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.5725 -11 5
+      vertex 13.5725 -11 2
+      vertex -13.5725 -11 2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -19.5725 17.2 1
+      vertex -19.5725 17.211 2.5
+      vertex -19.5725 17.211 1
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -19.5725 17.211 2.5
+      vertex -19.5725 17.2 1
+      vertex -19.5725 17.2 2.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -19.5725 42.789 1
+      vertex -19.5725 42.8 2.5
+      vertex -19.5725 42.8 1
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -19.5725 42.8 2.5
+      vertex -19.5725 42.789 1
+      vertex -19.5725 42.789 2.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5725 24 2.5
+      vertex -19.5725 17.211 2.5
+      vertex 13.6275 24 2.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5725 19.2 2.5
+      vertex -19.5725 17.211 2.5
+      vertex -21.5725 24 2.5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -20.5725 17.4679 2.5
+      vertex -19.5725 17.211 2.5
+      vertex -21.5725 19.2 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 17.211 2.5
+      vertex -20.1905 17.2979 2.5
+      vertex -19.7816 17.211 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 17.211 2.5
+      vertex -20.5725 17.4679 2.5
+      vertex -20.1905 17.2979 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5725 17.4679 2.5
+      vertex -21.5725 19.2 2.5
+      vertex -20.9108 17.7137 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9108 17.7137 2.5
+      vertex -21.5725 19.2 2.5
+      vertex -21.1905 18.0244 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1905 18.0244 2.5
+      vertex -21.5725 19.2 2.5
+      vertex -21.3996 18.3865 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.3996 18.3865 2.5
+      vertex -21.5725 19.2 2.5
+      vertex -21.5288 18.7842 2.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.6275 24 2.5
+      vertex 21.5725 19.2 2.5
+      vertex 21.5725 25 2.5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 19.5725 17.211 2.5
+      vertex 21.5725 19.2 2.5
+      vertex 13.6275 24 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5288 18.7842 2.5
+      vertex 19.5725 17.211 2.5
+      vertex 21.3996 18.3865 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.3996 18.3865 2.5
+      vertex 19.5725 17.211 2.5
+      vertex 21.1905 18.0244 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.1905 18.0244 2.5
+      vertex 19.5725 17.211 2.5
+      vertex 20.9108 17.7137 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.9108 17.7137 2.5
+      vertex 19.5725 17.211 2.5
+      vertex 20.5725 17.4679 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5725 17.4679 2.5
+      vertex 19.5725 17.211 2.5
+      vertex 20.1905 17.2979 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1905 17.2979 2.5
+      vertex 19.5725 17.211 2.5
+      vertex 19.7816 17.211 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6275 24 2.5
+      vertex 21.5725 25 2.5
+      vertex 13.6275 25 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5725 19.2 2.5
+      vertex 19.5725 17.211 2.5
+      vertex 21.5288 18.7842 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 17.211 2.5
+      vertex 13.6275 24 2.5
+      vertex 19.5725 17.2 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 17.2 2.5
+      vertex 13.6275 24 2.5
+      vertex -19.5725 17.211 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6275 24 2.5
+      vertex -19.5725 17.2 2.5
+      vertex 19.5725 17.2 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 42.8 2.5
+      vertex 13.6275 36 2.5
+      vertex 19.5725 42.789 2.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.5725 42.8 2.5
+      vertex 13.6275 36 2.5
+      vertex 19.5725 42.8 2.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.5725 42.789 2.5
+      vertex 13.6275 36 2.5
+      vertex -19.5725 42.8 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1905 42.7021 2.5
+      vertex -19.5725 42.789 2.5
+      vertex -19.7816 42.789 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5725 42.5321 2.5
+      vertex -19.5725 42.789 2.5
+      vertex -20.1905 42.7021 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 42.789 2.5
+      vertex -20.5725 42.5321 2.5
+      vertex -21.5725 40.8 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 40.8 2.5
+      vertex -20.5725 42.5321 2.5
+      vertex -20.9108 42.2863 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 40.8 2.5
+      vertex -20.9108 42.2863 2.5
+      vertex -21.1905 41.9756 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 40.8 2.5
+      vertex -21.1905 41.9756 2.5
+      vertex -21.3996 41.6135 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 40.8 2.5
+      vertex -21.3996 41.6135 2.5
+      vertex -21.5288 41.2158 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 42.789 2.5
+      vertex -21.5725 40.8 2.5
+      vertex -21.5725 36 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5725 42.789 2.5
+      vertex -21.5725 36 2.5
+      vertex 13.6275 36 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 21.5725 40.8 2.5
+      vertex 21.5288 41.2158 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 21.5288 41.2158 2.5
+      vertex 21.3996 41.6135 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 21.3996 41.6135 2.5
+      vertex 21.1905 41.9756 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 21.1905 41.9756 2.5
+      vertex 20.9108 42.2863 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 20.9108 42.2863 2.5
+      vertex 20.5725 42.5321 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 20.5725 42.5321 2.5
+      vertex 20.1905 42.7021 2.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 20.1905 42.7021 2.5
+      vertex 19.7816 42.789 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5725 40.8 2.5
+      vertex 19.5725 42.789 2.5
+      vertex 13.6275 36 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5725 40.8 2.5
+      vertex 13.6275 36 2.5
+      vertex 21.5725 35 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5725 35 2.5
+      vertex 13.6275 36 2.5
+      vertex 13.6275 35 2.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 19.5725 17.2 2.5
+      vertex 19.5725 17.211 1
+      vertex 19.5725 17.211 2.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 19.5725 17.211 1
+      vertex 19.5725 17.2 2.5
+      vertex 19.5725 17.2 1
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 19.5725 42.8 1
+      vertex 19.5725 42.8 2.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 19.5725 42.8 1
+      vertex 19.5725 42.789 2.5
+      vertex 19.5725 42.789 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0219 21.7921 1
+      vertex -17.0219 22.2079 1
+      vertex -17 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0865 21.5933 1
+      vertex -17.0219 22.2079 1
+      vertex -17.0219 21.7921 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0865 21.5933 1
+      vertex -17.0865 22.4067 1
+      vertex -17.0219 22.2079 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.191 21.4122 1
+      vertex -17.0865 22.4067 1
+      vertex -17.0865 21.5933 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.191 21.4122 1
+      vertex -17.191 22.5878 1
+      vertex -17.0865 22.4067 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3309 21.2569 1
+      vertex -17.191 22.5878 1
+      vertex -17.191 21.4122 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3309 21.2569 1
+      vertex -17.3309 22.7431 1
+      vertex -17.191 22.5878 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5 21.134 1
+      vertex -17.3309 22.7431 1
+      vertex -17.3309 21.2569 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5 21.134 1
+      vertex -17.5 22.866 1
+      vertex -17.3309 22.7431 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.691 21.0489 1
+      vertex -17.5 22.866 1
+      vertex -17.5 21.134 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.691 21.0489 1
+      vertex -17.691 22.9511 1
+      vertex -17.5 22.866 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8955 21.0055 1
+      vertex -17.691 22.9511 1
+      vertex -17.691 21.0489 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8955 21.0055 1
+      vertex -17.8955 22.9945 1
+      vertex -17.691 22.9511 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.1045 21.0055 1
+      vertex -17.8955 22.9945 1
+      vertex -17.8955 21.0055 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.1045 21.0055 1
+      vertex -18.1045 22.9945 1
+      vertex -17.8955 22.9945 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.309 21.0489 1
+      vertex -18.1045 22.9945 1
+      vertex -18.1045 21.0055 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.309 21.0489 1
+      vertex -18.309 22.9511 1
+      vertex -18.1045 22.9945 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 21.134 1
+      vertex -18.309 22.9511 1
+      vertex -18.309 21.0489 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 21.134 1
+      vertex -18.5 22.866 1
+      vertex -18.309 22.9511 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6691 21.2569 1
+      vertex -18.5 22.866 1
+      vertex -18.5 21.134 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6691 21.2569 1
+      vertex -18.6691 22.7431 1
+      vertex -18.5 22.866 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.809 21.4122 1
+      vertex -18.6691 22.7431 1
+      vertex -18.6691 21.2569 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.809 21.4122 1
+      vertex -18.809 22.5878 1
+      vertex -18.6691 22.7431 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9135 21.5933 1
+      vertex -18.809 22.5878 1
+      vertex -18.809 21.4122 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9135 21.5933 1
+      vertex -18.9135 22.4067 1
+      vertex -18.809 22.5878 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9781 21.7921 1
+      vertex -18.9135 22.4067 1
+      vertex -18.9135 21.5933 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9781 21.7921 1
+      vertex -18.9781 22.2079 1
+      vertex -18.9135 22.4067 1
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -18.9781 22.2079 1
+      vertex -18.9781 21.7921 1
+      vertex -19 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0219 37.7921 1
+      vertex -17.0219 38.2079 1
+      vertex -17 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0865 37.5933 1
+      vertex -17.0219 38.2079 1
+      vertex -17.0219 37.7921 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0865 37.5933 1
+      vertex -17.0865 38.4067 1
+      vertex -17.0219 38.2079 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.191 37.4122 1
+      vertex -17.0865 38.4067 1
+      vertex -17.0865 37.5933 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.191 37.4122 1
+      vertex -17.191 38.5878 1
+      vertex -17.0865 38.4067 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3309 37.2569 1
+      vertex -17.191 38.5878 1
+      vertex -17.191 37.4122 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3309 37.2569 1
+      vertex -17.3309 38.7431 1
+      vertex -17.191 38.5878 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5 37.134 1
+      vertex -17.3309 38.7431 1
+      vertex -17.3309 37.2569 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5 37.134 1
+      vertex -17.5 38.866 1
+      vertex -17.3309 38.7431 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.691 37.0489 1
+      vertex -17.5 38.866 1
+      vertex -17.5 37.134 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.691 37.0489 1
+      vertex -17.691 38.9511 1
+      vertex -17.5 38.866 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8955 37.0055 1
+      vertex -17.691 38.9511 1
+      vertex -17.691 37.0489 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8955 37.0055 1
+      vertex -17.8955 38.9945 1
+      vertex -17.691 38.9511 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.1045 37.0055 1
+      vertex -17.8955 38.9945 1
+      vertex -17.8955 37.0055 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.1045 37.0055 1
+      vertex -18.1045 38.9945 1
+      vertex -17.8955 38.9945 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.309 37.0489 1
+      vertex -18.1045 38.9945 1
+      vertex -18.1045 37.0055 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.309 37.0489 1
+      vertex -18.309 38.9511 1
+      vertex -18.1045 38.9945 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 37.134 1
+      vertex -18.309 38.9511 1
+      vertex -18.309 37.0489 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 37.134 1
+      vertex -18.5 38.866 1
+      vertex -18.309 38.9511 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6691 37.2569 1
+      vertex -18.5 38.866 1
+      vertex -18.5 37.134 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6691 37.2569 1
+      vertex -18.6691 38.7431 1
+      vertex -18.5 38.866 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.809 37.4122 1
+      vertex -18.6691 38.7431 1
+      vertex -18.6691 37.2569 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.809 37.4122 1
+      vertex -18.809 38.5878 1
+      vertex -18.6691 38.7431 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9135 37.5933 1
+      vertex -18.809 38.5878 1
+      vertex -18.809 37.4122 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9135 37.5933 1
+      vertex -18.9135 38.4067 1
+      vertex -18.809 38.5878 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9781 37.7921 1
+      vertex -18.9135 38.4067 1
+      vertex -18.9135 37.5933 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9781 37.7921 1
+      vertex -18.9781 38.2079 1
+      vertex -18.9135 38.4067 1
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -18.9781 38.2079 1
+      vertex -18.9781 37.7921 1
+      vertex -19 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9781 21.7921 1
+      vertex 18.9781 22.2079 1
+      vertex 19 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9135 21.5933 1
+      vertex 18.9781 22.2079 1
+      vertex 18.9781 21.7921 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9135 21.5933 1
+      vertex 18.9135 22.4067 1
+      vertex 18.9781 22.2079 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.809 21.4122 1
+      vertex 18.9135 22.4067 1
+      vertex 18.9135 21.5933 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.809 21.4122 1
+      vertex 18.809 22.5878 1
+      vertex 18.9135 22.4067 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6691 21.2569 1
+      vertex 18.809 22.5878 1
+      vertex 18.809 21.4122 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6691 21.2569 1
+      vertex 18.6691 22.7431 1
+      vertex 18.809 22.5878 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 21.134 1
+      vertex 18.6691 22.7431 1
+      vertex 18.6691 21.2569 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 21.134 1
+      vertex 18.5 22.866 1
+      vertex 18.6691 22.7431 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.309 21.0489 1
+      vertex 18.5 22.866 1
+      vertex 18.5 21.134 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.309 21.0489 1
+      vertex 18.309 22.9511 1
+      vertex 18.5 22.866 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.1045 21.0055 1
+      vertex 18.309 22.9511 1
+      vertex 18.309 21.0489 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.1045 21.0055 1
+      vertex 18.1045 22.9945 1
+      vertex 18.309 22.9511 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8955 21.0055 1
+      vertex 18.1045 22.9945 1
+      vertex 18.1045 21.0055 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8955 21.0055 1
+      vertex 17.8955 22.9945 1
+      vertex 18.1045 22.9945 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.691 21.0489 1
+      vertex 17.8955 22.9945 1
+      vertex 17.8955 21.0055 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.691 21.0489 1
+      vertex 17.691 22.9511 1
+      vertex 17.8955 22.9945 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5 21.134 1
+      vertex 17.691 22.9511 1
+      vertex 17.691 21.0489 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5 21.134 1
+      vertex 17.5 22.866 1
+      vertex 17.691 22.9511 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3309 21.2569 1
+      vertex 17.5 22.866 1
+      vertex 17.5 21.134 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3309 21.2569 1
+      vertex 17.3309 22.7431 1
+      vertex 17.5 22.866 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.191 21.4122 1
+      vertex 17.3309 22.7431 1
+      vertex 17.3309 21.2569 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.191 21.4122 1
+      vertex 17.191 22.5878 1
+      vertex 17.3309 22.7431 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0865 21.5933 1
+      vertex 17.191 22.5878 1
+      vertex 17.191 21.4122 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0865 21.5933 1
+      vertex 17.0865 22.4067 1
+      vertex 17.191 22.5878 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0219 21.7921 1
+      vertex 17.0865 22.4067 1
+      vertex 17.0865 21.5933 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0219 21.7921 1
+      vertex 17.0219 22.2079 1
+      vertex 17.0865 22.4067 1
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 17.0219 22.2079 1
+      vertex 17.0219 21.7921 1
+      vertex 17 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9781 37.7921 1
+      vertex 18.9781 38.2079 1
+      vertex 19 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9135 37.5933 1
+      vertex 18.9781 38.2079 1
+      vertex 18.9781 37.7921 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9135 37.5933 1
+      vertex 18.9135 38.4067 1
+      vertex 18.9781 38.2079 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.809 37.4122 1
+      vertex 18.9135 38.4067 1
+      vertex 18.9135 37.5933 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.809 37.4122 1
+      vertex 18.809 38.5878 1
+      vertex 18.9135 38.4067 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6691 37.2569 1
+      vertex 18.809 38.5878 1
+      vertex 18.809 37.4122 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6691 37.2569 1
+      vertex 18.6691 38.7431 1
+      vertex 18.809 38.5878 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 37.134 1
+      vertex 18.6691 38.7431 1
+      vertex 18.6691 37.2569 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 37.134 1
+      vertex 18.5 38.866 1
+      vertex 18.6691 38.7431 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.309 37.0489 1
+      vertex 18.5 38.866 1
+      vertex 18.5 37.134 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.309 37.0489 1
+      vertex 18.309 38.9511 1
+      vertex 18.5 38.866 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.1045 37.0055 1
+      vertex 18.309 38.9511 1
+      vertex 18.309 37.0489 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.1045 37.0055 1
+      vertex 18.1045 38.9945 1
+      vertex 18.309 38.9511 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8955 37.0055 1
+      vertex 18.1045 38.9945 1
+      vertex 18.1045 37.0055 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8955 37.0055 1
+      vertex 17.8955 38.9945 1
+      vertex 18.1045 38.9945 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.691 37.0489 1
+      vertex 17.8955 38.9945 1
+      vertex 17.8955 37.0055 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.691 37.0489 1
+      vertex 17.691 38.9511 1
+      vertex 17.8955 38.9945 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5 37.134 1
+      vertex 17.691 38.9511 1
+      vertex 17.691 37.0489 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5 37.134 1
+      vertex 17.5 38.866 1
+      vertex 17.691 38.9511 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3309 37.2569 1
+      vertex 17.5 38.866 1
+      vertex 17.5 37.134 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3309 37.2569 1
+      vertex 17.3309 38.7431 1
+      vertex 17.5 38.866 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.191 37.4122 1
+      vertex 17.3309 38.7431 1
+      vertex 17.3309 37.2569 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.191 37.4122 1
+      vertex 17.191 38.5878 1
+      vertex 17.3309 38.7431 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0865 37.5933 1
+      vertex 17.191 38.5878 1
+      vertex 17.191 37.4122 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0865 37.5933 1
+      vertex 17.0865 38.4067 1
+      vertex 17.191 38.5878 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0219 37.7921 1
+      vertex 17.0865 38.4067 1
+      vertex 17.0865 37.5933 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0219 37.7921 1
+      vertex 17.0219 38.2079 1
+      vertex 17.0865 38.4067 1
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 17.0219 38.2079 1
+      vertex 17.0219 37.7921 1
+      vertex 17 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 40.8 1
+      vertex -19.4721 39.6349 1
+      vertex -19.7798 39.2931 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -20.1905 42.7021 1
+      vertex -19.5725 42.789 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 40.8 1
+      vertex -19.7798 39.2931 1
+      vertex -20.0098 38.8948 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 40.8 1
+      vertex -20.0098 38.8948 1
+      vertex -20.1519 38.4574 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -21.5725 40.8 1
+      vertex -21.5288 41.2158 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 40.8 1
+      vertex -20.1519 38.4574 1
+      vertex -20.2 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 40.8 1
+      vertex -20.1519 37.5426 1
+      vertex -21.5725 33 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.5725 42.789 1
+      vertex -20.1905 42.7021 1
+      vertex -19.7816 42.789 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6275 33 1
+      vertex -15.8481 37.5426 1
+      vertex -15.8 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6275 33 1
+      vertex -15.9902 37.1052 1
+      vertex -15.8481 37.5426 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6275 33 1
+      vertex -16.2202 36.7069 1
+      vertex -15.9902 37.1052 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6275 33 1
+      vertex -16.5279 36.3651 1
+      vertex -16.2202 36.7069 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6275 33 1
+      vertex -16.9 36.0947 1
+      vertex -16.5279 36.3651 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5725 33 1
+      vertex -16.9 36.0947 1
+      vertex 12.6275 33 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.9 36.0947 1
+      vertex -20.5725 33 1
+      vertex -17.3202 35.9077 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3202 35.9077 1
+      vertex -20.5725 33 1
+      vertex -17.77 35.8121 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.0098 37.1052 1
+      vertex -21.5725 33 1
+      vertex -20.1519 37.5426 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.7798 36.7069 1
+      vertex -21.5725 33 1
+      vertex -20.0098 37.1052 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.4721 36.3651 1
+      vertex -21.5725 33 1
+      vertex -19.7798 36.7069 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 33 1
+      vertex -19.4721 36.3651 1
+      vertex -20.5725 33 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.1 36.0947 1
+      vertex -20.5725 33 1
+      vertex -19.4721 36.3651 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.6798 35.9077 1
+      vertex -20.5725 33 1
+      vertex -19.1 36.0947 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.23 35.8121 1
+      vertex -20.5725 33 1
+      vertex -18.6798 35.9077 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.77 35.8121 1
+      vertex -20.5725 33 1
+      vertex -18.23 35.8121 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3202 19.9077 1
+      vertex 19.5725 17.211 1
+      vertex 19.5725 17.2 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5725 17.211 1
+      vertex 19.1 20.0947 1
+      vertex 19.4721 20.3651 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5725 17.211 1
+      vertex 18.6798 19.9077 1
+      vertex 19.1 20.0947 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5725 17.211 1
+      vertex 18.23 19.8121 1
+      vertex 18.6798 19.9077 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5725 17.211 1
+      vertex 17.77 19.8121 1
+      vertex 18.23 19.8121 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5725 17.211 1
+      vertex 17.3202 19.9077 1
+      vertex 17.77 19.8121 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5725 17.2 1
+      vertex 16.9 20.0947 1
+      vertex 17.3202 19.9077 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5725 17.2 1
+      vertex 16.5279 20.3651 1
+      vertex 16.9 20.0947 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8481 21.5426 1
+      vertex 13.6275 25 1
+      vertex 15.8 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9902 21.1052 1
+      vertex 13.6275 25 1
+      vertex 15.8481 21.5426 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9902 21.1052 1
+      vertex 15.9902 21.1052 1
+      vertex 16.2202 20.7069 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6275 25 1
+      vertex 12.6275 27 1
+      vertex 13.6275 35 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8481 21.5426 1
+      vertex 12.6275 27 1
+      vertex 13.6275 25 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9902 21.1052 1
+      vertex -15.9902 21.1052 1
+      vertex 13.6275 25 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.2202 20.7069 1
+      vertex 16.2202 20.7069 1
+      vertex 16.5279 20.3651 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5279 20.3651 1
+      vertex 16.5279 20.3651 1
+      vertex 19.5725 17.2 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6275 27 1
+      vertex -15.8481 21.5426 1
+      vertex -15.8 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6275 25 1
+      vertex -15.9902 21.1052 1
+      vertex -15.8481 21.5426 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.2202 20.7069 1
+      vertex -16.2202 20.7069 1
+      vertex -15.9902 21.1052 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5279 20.3651 1
+      vertex -16.5279 20.3651 1
+      vertex -16.2202 20.7069 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 17.2 1
+      vertex -16.5279 20.3651 1
+      vertex 19.5725 17.2 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5279 20.3651 1
+      vertex -19.5725 17.2 1
+      vertex -16.9 20.0947 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.9 20.0947 1
+      vertex -19.5725 17.2 1
+      vertex -17.3202 19.9077 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 17.211 1
+      vertex -17.3202 19.9077 1
+      vertex -19.5725 17.2 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3202 19.9077 1
+      vertex -19.5725 17.211 1
+      vertex -17.77 19.8121 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.77 19.8121 1
+      vertex -19.5725 17.211 1
+      vertex -18.23 19.8121 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.23 19.8121 1
+      vertex -19.5725 17.211 1
+      vertex -18.6798 19.9077 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.6798 19.9077 1
+      vertex -19.5725 17.211 1
+      vertex -19.1 20.0947 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1905 17.2979 1
+      vertex -19.1 20.0947 1
+      vertex -19.5725 17.211 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5725 17.4679 1
+      vertex -19.1 20.0947 1
+      vertex -20.1905 17.2979 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1905 17.2979 1
+      vertex -19.5725 17.211 1
+      vertex -19.7816 17.211 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.9108 17.7137 1
+      vertex -19.1 20.0947 1
+      vertex -20.5725 17.4679 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1905 18.0244 1
+      vertex -19.1 20.0947 1
+      vertex -20.9108 17.7137 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.3996 18.3865 1
+      vertex -19.1 20.0947 1
+      vertex -21.1905 18.0244 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.0098 21.1052 1
+      vertex -21.5725 19.2 1
+      vertex -20.1519 21.5426 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.7798 20.7069 1
+      vertex -21.5725 19.2 1
+      vertex -20.0098 21.1052 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5288 18.7842 1
+      vertex 19.4721 20.3651 1
+      vertex 21.5725 19.2 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 19.2 1
+      vertex 20.1519 21.5426 1
+      vertex 20.2 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 19.2 1
+      vertex 20.0098 21.1052 1
+      vertex 20.1519 21.5426 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5725 17.211 1
+      vertex 20.1905 17.2979 1
+      vertex 19.7816 17.211 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 19.2 1
+      vertex 19.7798 20.7069 1
+      vertex 20.0098 21.1052 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.1905 17.2979 1
+      vertex 19.5725 17.211 1
+      vertex 19.4721 20.3651 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 19.2 1
+      vertex 19.4721 20.3651 1
+      vertex 19.7798 20.7069 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.3996 18.3865 1
+      vertex 19.4721 20.3651 1
+      vertex 21.5288 18.7842 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1905 18.0244 1
+      vertex 19.4721 20.3651 1
+      vertex 21.3996 18.3865 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.9108 17.7137 1
+      vertex 19.4721 20.3651 1
+      vertex 21.1905 18.0244 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.4721 20.3651 1
+      vertex 20.9108 17.7137 1
+      vertex 20.5725 17.4679 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.4721 20.3651 1
+      vertex 20.5725 17.4679 1
+      vertex 20.1905 17.2979 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 19.2 1
+      vertex 20.2 22 1
+      vertex 21.5725 25 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1519 22.4574 1
+      vertex 21.5725 25 1
+      vertex 20.2 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.0098 22.8948 1
+      vertex 21.5725 25 1
+      vertex 20.1519 22.4574 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7798 23.2931 1
+      vertex 21.5725 25 1
+      vertex 20.0098 22.8948 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.4721 23.6349 1
+      vertex 21.5725 25 1
+      vertex 19.7798 23.2931 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.1 23.9053 1
+      vertex 21.5725 25 1
+      vertex 19.4721 23.6349 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6798 24.0923 1
+      vertex 21.5725 25 1
+      vertex 19.1 23.9053 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.23 24.1879 1
+      vertex 21.5725 25 1
+      vertex 18.6798 24.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.77 24.1879 1
+      vertex 21.5725 25 1
+      vertex 18.23 24.1879 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6275 25 1
+      vertex 17.77 24.1879 1
+      vertex 17.3202 24.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.77 24.1879 1
+      vertex 13.6275 25 1
+      vertex 21.5725 25 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.9 23.9053 1
+      vertex 13.6275 25 1
+      vertex 17.3202 24.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5279 23.6349 1
+      vertex 13.6275 25 1
+      vertex 16.9 23.9053 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.2202 23.2931 1
+      vertex 13.6275 25 1
+      vertex 16.5279 23.6349 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9902 22.8948 1
+      vertex 13.6275 25 1
+      vertex 16.2202 23.2931 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8481 22.4574 1
+      vertex 13.6275 25 1
+      vertex 15.9902 22.8948 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6275 25 1
+      vertex 15.8481 22.4574 1
+      vertex 15.8 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8481 22.4574 1
+      vertex 12.6275 27 1
+      vertex -15.8 22 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9902 22.8948 1
+      vertex 12.6275 27 1
+      vertex -15.8481 22.4574 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.2202 23.2931 1
+      vertex 12.6275 27 1
+      vertex -15.9902 22.8948 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5279 23.6349 1
+      vertex 12.6275 27 1
+      vertex -16.2202 23.2931 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.9 23.9053 1
+      vertex 12.6275 27 1
+      vertex -16.5279 23.6349 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5725 27 1
+      vertex -16.9 23.9053 1
+      vertex -17.3202 24.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5725 27 1
+      vertex -17.3202 24.0923 1
+      vertex -17.77 24.1879 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5725 27 1
+      vertex -17.77 24.1879 1
+      vertex -18.23 24.1879 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.9 23.9053 1
+      vertex -20.5725 27 1
+      vertex 12.6275 27 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6798 24.0923 1
+      vertex -20.5725 27 1
+      vertex -18.23 24.1879 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.1 23.9053 1
+      vertex -20.5725 27 1
+      vertex -18.6798 24.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 23.6349 1
+      vertex -20.5725 27 1
+      vertex -19.1 23.9053 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 27 1
+      vertex -19.4721 23.6349 1
+      vertex -19.7798 23.2931 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 27 1
+      vertex -19.7798 23.2931 1
+      vertex -20.0098 22.8948 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 27 1
+      vertex -20.0098 22.8948 1
+      vertex -20.1519 22.4574 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 19.2 1
+      vertex -20.1519 22.4574 1
+      vertex -20.2 22 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.1519 21.5426 1
+      vertex -21.5725 19.2 1
+      vertex -20.2 22 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.1519 22.4574 1
+      vertex -21.5725 19.2 1
+      vertex -21.5725 27 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5725 27 1
+      vertex -21.5725 27 1
+      vertex -20.5725 33 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5288 18.7842 1
+      vertex -19.1 20.0947 1
+      vertex -21.3996 18.3865 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 33 1
+      vertex -20.5725 33 1
+      vertex -21.5725 27 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.1 20.0947 1
+      vertex -21.5288 18.7842 1
+      vertex -19.4721 20.3651 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1519 37.5426 1
+      vertex -21.5725 40.8 1
+      vertex -20.2 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5725 19.2 1
+      vertex -19.4721 20.3651 1
+      vertex -21.5288 18.7842 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -20.5725 42.5321 1
+      vertex -20.1905 42.7021 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.4721 20.3651 1
+      vertex -21.5725 19.2 1
+      vertex -19.7798 20.7069 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -20.9108 42.2863 1
+      vertex -20.5725 42.5321 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 23.6349 1
+      vertex -21.5725 27 1
+      vertex -20.5725 27 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -21.1905 41.9756 1
+      vertex -20.9108 42.2863 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -21.3996 41.6135 1
+      vertex -21.1905 41.9756 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -21.5288 41.2158 1
+      vertex -21.3996 41.6135 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.2 38 1
+      vertex 21.5725 40.8 1
+      vertex 21.5725 35 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1519 38.4574 1
+      vertex 21.5725 40.8 1
+      vertex 20.2 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.0098 38.8948 1
+      vertex 21.5725 40.8 1
+      vertex 20.1519 38.4574 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7798 39.2931 1
+      vertex 21.5725 40.8 1
+      vertex 20.0098 38.8948 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.5725 40.8 1
+      vertex 19.4721 39.6349 1
+      vertex 21.5288 41.2158 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.4721 39.6349 1
+      vertex 21.5725 40.8 1
+      vertex 19.7798 39.2931 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 35 1
+      vertex 20.1519 37.5426 1
+      vertex 20.2 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 35 1
+      vertex 20.0098 37.1052 1
+      vertex 20.1519 37.5426 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 35 1
+      vertex 19.7798 36.7069 1
+      vertex 20.0098 37.1052 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 35 1
+      vertex 19.4721 36.3651 1
+      vertex 19.7798 36.7069 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 35 1
+      vertex 19.1 36.0947 1
+      vertex 19.4721 36.3651 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 35 1
+      vertex 18.6798 35.9077 1
+      vertex 19.1 36.0947 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 35 1
+      vertex 18.23 35.8121 1
+      vertex 18.6798 35.9077 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5725 35 1
+      vertex 17.77 35.8121 1
+      vertex 18.23 35.8121 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6275 35 1
+      vertex 17.77 35.8121 1
+      vertex 21.5725 35 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.8481 37.5426 1
+      vertex 13.6275 35 1
+      vertex 15.8 38 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.9902 37.1052 1
+      vertex 13.6275 35 1
+      vertex 15.8481 37.5426 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.2202 36.7069 1
+      vertex 13.6275 35 1
+      vertex 15.9902 37.1052 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.5279 36.3651 1
+      vertex 13.6275 35 1
+      vertex 16.2202 36.7069 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.9 36.0947 1
+      vertex 13.6275 35 1
+      vertex 16.5279 36.3651 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.3202 35.9077 1
+      vertex 13.6275 35 1
+      vertex 16.9 36.0947 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.77 35.8121 1
+      vertex 13.6275 35 1
+      vertex 17.3202 35.9077 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.1 39.9053 1
+      vertex 21.5288 41.2158 1
+      vertex 19.4721 39.6349 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.5288 41.2158 1
+      vertex 19.1 39.9053 1
+      vertex 21.3996 41.6135 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.3996 41.6135 1
+      vertex 19.1 39.9053 1
+      vertex 21.1905 41.9756 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.1905 41.9756 1
+      vertex 19.1 39.9053 1
+      vertex 20.9108 42.2863 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.9108 42.2863 1
+      vertex 19.1 39.9053 1
+      vertex 20.5725 42.5321 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.5725 42.5321 1
+      vertex 19.1 39.9053 1
+      vertex 20.1905 42.7021 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.1905 42.7021 1
+      vertex 19.1 39.9053 1
+      vertex 19.7816 42.789 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.7816 42.789 1
+      vertex 19.1 39.9053 1
+      vertex 19.5725 42.789 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6798 40.0923 1
+      vertex 19.5725 42.789 1
+      vertex 19.1 39.9053 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.23 40.1879 1
+      vertex 19.5725 42.789 1
+      vertex 18.6798 40.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.77 40.1879 1
+      vertex 19.5725 42.789 1
+      vertex 18.23 40.1879 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3202 40.0923 1
+      vertex 19.5725 42.789 1
+      vertex 17.77 40.1879 1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.5725 42.789 1
+      vertex 17.3202 40.0923 1
+      vertex 19.5725 42.8 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.9 39.9053 1
+      vertex 19.5725 42.8 1
+      vertex 17.3202 40.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5279 39.6349 1
+      vertex 19.5725 42.8 1
+      vertex 16.9 39.9053 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6275 35 1
+      vertex 15.8481 38.4574 1
+      vertex 15.8 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6275 35 1
+      vertex 15.9902 38.8948 1
+      vertex 15.8481 38.4574 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9902 38.8948 1
+      vertex 15.9902 38.8948 1
+      vertex 13.6275 35 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6275 33 1
+      vertex 13.6275 35 1
+      vertex 12.6275 27 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8481 38.4574 1
+      vertex 12.6275 33 1
+      vertex -15.8 38 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6275 33 1
+      vertex -15.8481 38.4574 1
+      vertex 13.6275 35 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9902 38.8948 1
+      vertex 13.6275 35 1
+      vertex -15.8481 38.4574 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9902 38.8948 1
+      vertex -15.9902 38.8948 1
+      vertex 16.2202 39.2931 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.2202 39.2931 1
+      vertex 16.2202 39.2931 1
+      vertex -15.9902 38.8948 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.2202 39.2931 1
+      vertex -16.2202 39.2931 1
+      vertex 16.5279 39.6349 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5279 39.6349 1
+      vertex 16.5279 39.6349 1
+      vertex -16.2202 39.2931 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5279 39.6349 1
+      vertex -16.5279 39.6349 1
+      vertex 19.5725 42.8 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 42.8 1
+      vertex -16.5279 39.6349 1
+      vertex -16.9 39.9053 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 42.8 1
+      vertex -16.9 39.9053 1
+      vertex -17.3202 40.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 42.789 1
+      vertex -17.3202 40.0923 1
+      vertex -17.77 40.1879 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 42.789 1
+      vertex -17.77 40.1879 1
+      vertex -18.23 40.1879 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 42.789 1
+      vertex -19.1 39.9053 1
+      vertex -19.4721 39.6349 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 42.789 1
+      vertex -18.6798 40.0923 1
+      vertex -19.1 39.9053 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5725 42.789 1
+      vertex -18.23 40.1879 1
+      vertex -18.6798 40.0923 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3202 40.0923 1
+      vertex -19.5725 42.789 1
+      vertex -19.5725 42.8 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5279 39.6349 1
+      vertex -19.5725 42.8 1
+      vertex 19.5725 42.8 1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -19.5725 17.2 1
+      vertex 19.5725 17.2 2.5
+      vertex -19.5725 17.2 2.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 19.5725 17.2 2.5
+      vertex -19.5725 17.2 1
+      vertex 19.5725 17.2 1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 19.5725 42.8 1
+      vertex -19.5725 42.8 2.5
+      vertex 19.5725 42.8 2.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -19.5725 42.8 2.5
+      vertex 19.5725 42.8 1
+      vertex -19.5725 42.8 1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 33 1
+      vertex -21.5725 27 1
+      vertex -21.5725 33 2.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 33 2.5
+      vertex -21.5725 34 9.75
+      vertex -21.5725 36 2.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 27 2.5
+      vertex -21.5725 33 2.5
+      vertex -21.5725 27 1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 33 2.5
+      vertex -21.5725 27 2.5
+      vertex -21.5725 34 9.75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 27 2.5
+      vertex -21.5725 26 9.75
+      vertex -21.5725 34 9.75
+    endloop
+  endfacet
+  facet normal -1 0 -0
+    outer loop
+      vertex -21.5725 26 9.75
+      vertex -21.5725 27 2.5
+      vertex -21.5725 24 2.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 27 1
+      vertex -21.5725 24 2.5
+      vertex -21.5725 27 2.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 19.2 1
+      vertex -21.5725 24 2.5
+      vertex -21.5725 27 1
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -21.5725 24 2.5
+      vertex -21.5725 19.2 1
+      vertex -21.5725 19.2 2.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 40.8 1
+      vertex -21.5725 36 2.5
+      vertex -21.5725 40.8 2.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -21.5725 33 1
+      vertex -21.5725 36 2.5
+      vertex -21.5725 40.8 1
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -21.5725 36 2.5
+      vertex -21.5725 33 1
+      vertex -21.5725 33 2.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 21.5725 19.2 2.5
+      vertex 21.5725 25 1
+      vertex 21.5725 25 2.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 21.5725 25 1
+      vertex 21.5725 19.2 2.5
+      vertex 21.5725 19.2 1
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 21.5725 35 2.5
+      vertex 21.5725 40.8 1
+      vertex 21.5725 40.8 2.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 21.5725 40.8 1
+      vertex 21.5725 35 2.5
+      vertex 21.5725 35 1
+    endloop
+  endfacet
+  facet normal 0.994522 0.104523 0
+    outer loop
+      vertex 21.5725 40.8 2.5
+      vertex 21.5288 41.2158 1
+      vertex 21.5288 41.2158 2.5
+    endloop
+  endfacet
+  facet normal 0.994522 0.104523 0
+    outer loop
+      vertex 21.5288 41.2158 1
+      vertex 21.5725 40.8 2.5
+      vertex 21.5725 40.8 1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 19.7816 42.789 1
+      vertex 19.5725 42.789 2.5
+      vertex 19.7816 42.789 2.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.5725 42.789 2.5
+      vertex 19.7816 42.789 1
+      vertex 19.5725 42.789 1
+    endloop
+  endfacet
+  facet normal 0.743211 0.669057 0
+    outer loop
+      vertex 21.1905 41.9756 2.5
+      vertex 20.9108 42.2863 1
+      vertex 20.9108 42.2863 2.5
+    endloop
+  endfacet
+  facet normal 0.743211 0.669057 0
+    outer loop
+      vertex 20.9108 42.2863 1
+      vertex 21.1905 41.9756 2.5
+      vertex 21.1905 41.9756 1
+    endloop
+  endfacet
+  facet normal 0.951071 0.308973 0
+    outer loop
+      vertex 21.5288 41.2158 2.5
+      vertex 21.3996 41.6135 1
+      vertex 21.3996 41.6135 2.5
+    endloop
+  endfacet
+  facet normal 0.951071 0.308973 0
+    outer loop
+      vertex 21.3996 41.6135 1
+      vertex 21.5288 41.2158 2.5
+      vertex 21.5288 41.2158 1
+    endloop
+  endfacet
+  facet normal 0.865982 0.500074 0
+    outer loop
+      vertex 21.3996 41.6135 2.5
+      vertex 21.1905 41.9756 1
+      vertex 21.1905 41.9756 2.5
+    endloop
+  endfacet
+  facet normal 0.865982 0.500074 0
+    outer loop
+      vertex 21.1905 41.9756 1
+      vertex 21.3996 41.6135 2.5
+      vertex 21.3996 41.6135 1
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 -0
+    outer loop
+      vertex 20.5725 42.5321 1
+      vertex 20.1905 42.7021 2.5
+      vertex 20.5725 42.5321 2.5
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 0
+    outer loop
+      vertex 20.1905 42.7021 2.5
+      vertex 20.5725 42.5321 1
+      vertex 20.1905 42.7021 1
+    endloop
+  endfacet
+  facet normal 0.207879 0.978155 -0
+    outer loop
+      vertex 20.1905 42.7021 1
+      vertex 19.7816 42.789 2.5
+      vertex 20.1905 42.7021 2.5
+    endloop
+  endfacet
+  facet normal 0.207879 0.978155 0
+    outer loop
+      vertex 19.7816 42.789 2.5
+      vertex 20.1905 42.7021 1
+      vertex 19.7816 42.789 1
+    endloop
+  endfacet
+  facet normal 0.587802 0.809005 -0
+    outer loop
+      vertex 20.9108 42.2863 1
+      vertex 20.5725 42.5321 2.5
+      vertex 20.9108 42.2863 2.5
+    endloop
+  endfacet
+  facet normal 0.587802 0.809005 0
+    outer loop
+      vertex 20.5725 42.5321 2.5
+      vertex 20.9108 42.2863 1
+      vertex 20.5725 42.5321 1
+    endloop
+  endfacet
+  facet normal 0.743211 -0.669057 0
+    outer loop
+      vertex 20.9108 17.7137 2.5
+      vertex 21.1905 18.0244 1
+      vertex 21.1905 18.0244 2.5
+    endloop
+  endfacet
+  facet normal 0.743211 -0.669057 0
+    outer loop
+      vertex 21.1905 18.0244 1
+      vertex 20.9108 17.7137 2.5
+      vertex 20.9108 17.7137 1
+    endloop
+  endfacet
+  facet normal 0.865982 -0.500074 0
+    outer loop
+      vertex 21.1905 18.0244 2.5
+      vertex 21.3996 18.3865 1
+      vertex 21.3996 18.3865 2.5
+    endloop
+  endfacet
+  facet normal 0.865982 -0.500074 0
+    outer loop
+      vertex 21.3996 18.3865 1
+      vertex 21.1905 18.0244 2.5
+      vertex 21.1905 18.0244 1
+    endloop
+  endfacet
+  facet normal 0.207879 -0.978155 0
+    outer loop
+      vertex 19.7816 17.211 1
+      vertex 20.1905 17.2979 2.5
+      vertex 19.7816 17.211 2.5
+    endloop
+  endfacet
+  facet normal 0.207879 -0.978155 0
+    outer loop
+      vertex 20.1905 17.2979 2.5
+      vertex 19.7816 17.211 1
+      vertex 20.1905 17.2979 1
+    endloop
+  endfacet
+  facet normal 0.587802 -0.809005 0
+    outer loop
+      vertex 20.5725 17.4679 1
+      vertex 20.9108 17.7137 2.5
+      vertex 20.5725 17.4679 2.5
+    endloop
+  endfacet
+  facet normal 0.587802 -0.809005 0
+    outer loop
+      vertex 20.9108 17.7137 2.5
+      vertex 20.5725 17.4679 1
+      vertex 20.9108 17.7137 1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 19.5725 17.211 1
+      vertex 19.7816 17.211 2.5
+      vertex 19.5725 17.211 2.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 19.7816 17.211 2.5
+      vertex 19.5725 17.211 1
+      vertex 19.7816 17.211 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex 20.1905 17.2979 1
+      vertex 20.5725 17.4679 2.5
+      vertex 20.1905 17.2979 2.5
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex 20.5725 17.4679 2.5
+      vertex 20.1905 17.2979 1
+      vertex 20.5725 17.4679 1
+    endloop
+  endfacet
+  facet normal 0.951071 -0.308973 0
+    outer loop
+      vertex 21.3996 18.3865 2.5
+      vertex 21.5288 18.7842 1
+      vertex 21.5288 18.7842 2.5
+    endloop
+  endfacet
+  facet normal 0.951071 -0.308973 0
+    outer loop
+      vertex 21.5288 18.7842 1
+      vertex 21.3996 18.3865 2.5
+      vertex 21.3996 18.3865 1
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104523 0
+    outer loop
+      vertex 21.5288 18.7842 2.5
+      vertex 21.5725 19.2 1
+      vertex 21.5725 19.2 2.5
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104523 0
+    outer loop
+      vertex 21.5725 19.2 1
+      vertex 21.5288 18.7842 2.5
+      vertex 21.5288 18.7842 1
+    endloop
+  endfacet
+  facet normal -0.994522 0.104523 0
+    outer loop
+      vertex -21.5725 40.8 1
+      vertex -21.5288 41.2158 2.5
+      vertex -21.5288 41.2158 1
+    endloop
+  endfacet
+  facet normal -0.994522 0.104523 0
+    outer loop
+      vertex -21.5288 41.2158 2.5
+      vertex -21.5725 40.8 1
+      vertex -21.5725 40.8 2.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -19.5725 42.789 1
+      vertex -19.7816 42.789 2.5
+      vertex -19.5725 42.789 2.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -19.7816 42.789 2.5
+      vertex -19.5725 42.789 1
+      vertex -19.7816 42.789 1
+    endloop
+  endfacet
+  facet normal -0.587802 0.809005 0
+    outer loop
+      vertex -20.5725 42.5321 1
+      vertex -20.9108 42.2863 2.5
+      vertex -20.5725 42.5321 2.5
+    endloop
+  endfacet
+  facet normal -0.587802 0.809005 0
+    outer loop
+      vertex -20.9108 42.2863 2.5
+      vertex -20.5725 42.5321 1
+      vertex -20.9108 42.2863 1
+    endloop
+  endfacet
+  facet normal -0.207879 0.978155 0
+    outer loop
+      vertex -19.7816 42.789 1
+      vertex -20.1905 42.7021 2.5
+      vertex -19.7816 42.789 2.5
+    endloop
+  endfacet
+  facet normal -0.207879 0.978155 0
+    outer loop
+      vertex -20.1905 42.7021 2.5
+      vertex -19.7816 42.789 1
+      vertex -20.1905 42.7021 1
+    endloop
+  endfacet
+  facet normal -0.865982 0.500074 0
+    outer loop
+      vertex -21.3996 41.6135 1
+      vertex -21.1905 41.9756 2.5
+      vertex -21.1905 41.9756 1
+    endloop
+  endfacet
+  facet normal -0.865982 0.500074 0
+    outer loop
+      vertex -21.1905 41.9756 2.5
+      vertex -21.3996 41.6135 1
+      vertex -21.3996 41.6135 2.5
+    endloop
+  endfacet
+  facet normal -0.743211 0.669057 0
+    outer loop
+      vertex -21.1905 41.9756 1
+      vertex -20.9108 42.2863 2.5
+      vertex -20.9108 42.2863 1
+    endloop
+  endfacet
+  facet normal -0.743211 0.669057 0
+    outer loop
+      vertex -20.9108 42.2863 2.5
+      vertex -21.1905 41.9756 1
+      vertex -21.1905 41.9756 2.5
+    endloop
+  endfacet
+  facet normal -0.951071 0.308973 0
+    outer loop
+      vertex -21.5288 41.2158 1
+      vertex -21.3996 41.6135 2.5
+      vertex -21.3996 41.6135 1
+    endloop
+  endfacet
+  facet normal -0.951071 0.308973 0
+    outer loop
+      vertex -21.3996 41.6135 2.5
+      vertex -21.5288 41.2158 1
+      vertex -21.5288 41.2158 2.5
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex -20.1905 42.7021 1
+      vertex -20.5725 42.5321 2.5
+      vertex -20.1905 42.7021 2.5
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex -20.5725 42.5321 2.5
+      vertex -20.1905 42.7021 1
+      vertex -20.5725 42.5321 1
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104523 0
+    outer loop
+      vertex -21.5288 18.7842 1
+      vertex -21.5725 19.2 2.5
+      vertex -21.5725 19.2 1
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104523 0
+    outer loop
+      vertex -21.5725 19.2 2.5
+      vertex -21.5288 18.7842 1
+      vertex -21.5288 18.7842 2.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -19.7816 17.211 1
+      vertex -19.5725 17.211 2.5
+      vertex -19.7816 17.211 2.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -19.5725 17.211 2.5
+      vertex -19.7816 17.211 1
+      vertex -19.5725 17.211 1
+    endloop
+  endfacet
+  facet normal -0.743211 -0.669057 0
+    outer loop
+      vertex -20.9108 17.7137 1
+      vertex -21.1905 18.0244 2.5
+      vertex -21.1905 18.0244 1
+    endloop
+  endfacet
+  facet normal -0.743211 -0.669057 0
+    outer loop
+      vertex -21.1905 18.0244 2.5
+      vertex -20.9108 17.7137 1
+      vertex -20.9108 17.7137 2.5
+    endloop
+  endfacet
+  facet normal -0.951071 -0.308973 0
+    outer loop
+      vertex -21.3996 18.3865 1
+      vertex -21.5288 18.7842 2.5
+      vertex -21.5288 18.7842 1
+    endloop
+  endfacet
+  facet normal -0.951071 -0.308973 0
+    outer loop
+      vertex -21.5288 18.7842 2.5
+      vertex -21.3996 18.3865 1
+      vertex -21.3996 18.3865 2.5
+    endloop
+  endfacet
+  facet normal -0.587802 -0.809005 0
+    outer loop
+      vertex -20.9108 17.7137 1
+      vertex -20.5725 17.4679 2.5
+      vertex -20.9108 17.7137 2.5
+    endloop
+  endfacet
+  facet normal -0.587802 -0.809005 -0
+    outer loop
+      vertex -20.5725 17.4679 2.5
+      vertex -20.9108 17.7137 1
+      vertex -20.5725 17.4679 1
+    endloop
+  endfacet
+  facet normal -0.207879 -0.978155 0
+    outer loop
+      vertex -20.1905 17.2979 1
+      vertex -19.7816 17.211 2.5
+      vertex -20.1905 17.2979 2.5
+    endloop
+  endfacet
+  facet normal -0.207879 -0.978155 -0
+    outer loop
+      vertex -19.7816 17.211 2.5
+      vertex -20.1905 17.2979 1
+      vertex -19.7816 17.211 1
+    endloop
+  endfacet
+  facet normal -0.865982 -0.500074 0
+    outer loop
+      vertex -21.1905 18.0244 1
+      vertex -21.3996 18.3865 2.5
+      vertex -21.3996 18.3865 1
+    endloop
+  endfacet
+  facet normal -0.865982 -0.500074 0
+    outer loop
+      vertex -21.3996 18.3865 2.5
+      vertex -21.1905 18.0244 1
+      vertex -21.1905 18.0244 2.5
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 0
+    outer loop
+      vertex -20.5725 17.4679 1
+      vertex -20.1905 17.2979 2.5
+      vertex -20.5725 17.4679 2.5
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 -0
+    outer loop
+      vertex -20.1905 17.2979 2.5
+      vertex -20.5725 17.4679 1
+      vertex -20.1905 17.2979 1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 13.6275 35 1
+      vertex 21.5725 35 2.5
+      vertex 13.6275 35 2.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 21.5725 35 2.5
+      vertex 13.6275 35 1
+      vertex 21.5725 35 1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 21.5725 25 1
+      vertex 13.6275 25 2.5
+      vertex 21.5725 25 2.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 13.6275 25 2.5
+      vertex 21.5725 25 1
+      vertex 13.6275 25 1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 12.6275 27 1
+      vertex 12.6275 33 8.75
+      vertex 12.6275 33 1
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 12.6275 33 8.75
+      vertex 12.6275 27 1
+      vertex 12.6275 27 8.75
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -20.5725 33 9.75
+      vertex -15.5725 33 8.75
+      vertex -15.5725 33 9.75
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -20.5725 33 1
+      vertex -15.5725 33 8.75
+      vertex -20.5725 33 9.75
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12.6275 33 1
+      vertex -15.5725 33 8.75
+      vertex -20.5725 33 1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -15.5725 33 8.75
+      vertex 12.6275 33 1
+      vertex 12.6275 33 8.75
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.6275 27 8.75
+      vertex 12.6275 27 1
+      vertex -15.5725 27 8.75
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -15.5725 27 8.75
+      vertex -20.5725 27 9.75
+      vertex -15.5725 27 9.75
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -20.5725 27 1
+      vertex -15.5725 27 8.75
+      vertex 12.6275 27 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15.5725 27 8.75
+      vertex -20.5725 27 1
+      vertex -20.5725 27 9.75
+    endloop
+  endfacet
+  facet normal 0 -0.963993 0.265929
+    outer loop
+      vertex -21.5725 24 2.5
+      vertex 13.6275 26 9.75
+      vertex -21.5725 26 9.75
+    endloop
+  endfacet
+  facet normal 0 -0.963993 0.265929
+    outer loop
+      vertex 13.6275 26 9.75
+      vertex -21.5725 24 2.5
+      vertex 13.6275 24 2.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6275 34 9.75
+      vertex -15.5725 33 9.75
+      vertex 13.6275 26 9.75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5725 34 9.75
+      vertex -15.5725 33 9.75
+      vertex 13.6275 34 9.75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5725 33 9.75
+      vertex -21.5725 34 9.75
+      vertex -20.5725 27 9.75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.5725 33 9.75
+      vertex -21.5725 34 9.75
+      vertex -20.5725 33 9.75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.5725 27 9.75
+      vertex 13.6275 26 9.75
+      vertex -15.5725 33 9.75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 26 9.75
+      vertex -15.5725 27 9.75
+      vertex -20.5725 27 9.75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.5725 27 9.75
+      vertex -21.5725 26 9.75
+      vertex 13.6275 26 9.75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5725 26 9.75
+      vertex -20.5725 27 9.75
+      vertex -21.5725 34 9.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 13.6275 26 9.75
+      vertex 13.6275 24 2.5
+      vertex 13.6275 25 2.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 13.6275 34 9.75
+      vertex 13.6275 35 2.5
+      vertex 13.6275 36 2.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 13.6275 25 2.5
+      vertex 13.6275 35 2.5
+      vertex 13.6275 34 9.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 13.6275 25 2.5
+      vertex 13.6275 34 9.75
+      vertex 13.6275 26 9.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 13.6275 35 2.5
+      vertex 13.6275 25 2.5
+      vertex 13.6275 35 1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 13.6275 35 1
+      vertex 13.6275 25 2.5
+      vertex 13.6275 25 1
+    endloop
+  endfacet
+  facet normal 0 0.963993 0.265929
+    outer loop
+      vertex 13.6275 36 2.5
+      vertex -21.5725 34 9.75
+      vertex 13.6275 34 9.75
+    endloop
+  endfacet
+  facet normal 0 0.963993 0.265929
+    outer loop
+      vertex -21.5725 34 9.75
+      vertex 13.6275 36 2.5
+      vertex -21.5725 36 2.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.5725 27 8.75
+      vertex 12.6275 33 8.75
+      vertex 12.6275 27 8.75
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.6275 33 8.75
+      vertex -15.5725 27 8.75
+      vertex -15.5725 33 8.75
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -20.5725 27 9.75
+      vertex -20.5725 33 1
+      vertex -20.5725 33 9.75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -20.5725 33 1
+      vertex -20.5725 27 9.75
+      vertex -20.5725 27 1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -15.5725 27 8.75
+      vertex -15.5725 33 9.75
+      vertex -15.5725 33 8.75
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -15.5725 33 9.75
+      vertex -15.5725 27 8.75
+      vertex -15.5725 27 9.75
+    endloop
+  endfacet
+  facet normal 0.994516 0.104583 0
+    outer loop
+      vertex 20.2 38 1
+      vertex 20.1519 38.4574 0
+      vertex 20.1519 38.4574 1
+    endloop
+  endfacet
+  facet normal 0.994516 0.104583 0
+    outer loop
+      vertex 20.1519 38.4574 0
+      vertex 20.2 38 1
+      vertex 20.2 38 0
+    endloop
+  endfacet
+  facet normal -0.994516 0.104583 0
+    outer loop
+      vertex 15.8 38 0
+      vertex 15.8481 38.4574 1
+      vertex 15.8481 38.4574 0
+    endloop
+  endfacet
+  facet normal -0.994516 0.104583 0
+    outer loop
+      vertex 15.8481 38.4574 1
+      vertex 15.8 38 0
+      vertex 15.8 38 1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.23 40.1879 0
+      vertex 17.77 40.1879 1
+      vertex 18.23 40.1879 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.77 40.1879 1
+      vertex 18.23 40.1879 0
+      vertex 17.77 40.1879 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 17.77 35.8121 0
+      vertex 18.23 35.8121 1
+      vertex 17.77 35.8121 1
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.23 35.8121 1
+      vertex 17.77 35.8121 0
+      vertex 18.23 35.8121 0
+    endloop
+  endfacet
+  facet normal 0.743208 0.669061 0
+    outer loop
+      vertex 19.7798 39.2931 1
+      vertex 19.4721 39.6349 0
+      vertex 19.4721 39.6349 1
+    endloop
+  endfacet
+  facet normal 0.743208 0.669061 0
+    outer loop
+      vertex 19.4721 39.6349 0
+      vertex 19.7798 39.2931 1
+      vertex 19.7798 39.2931 0
+    endloop
+  endfacet
+  facet normal 0.951069 0.308978 0
+    outer loop
+      vertex 20.1519 38.4574 1
+      vertex 20.0098 38.8948 0
+      vertex 20.0098 38.8948 1
+    endloop
+  endfacet
+  facet normal 0.951069 0.308978 0
+    outer loop
+      vertex 20.0098 38.8948 0
+      vertex 20.1519 38.4574 1
+      vertex 20.1519 38.4574 0
+    endloop
+  endfacet
+  facet normal -0.587861 0.808962 0
+    outer loop
+      vertex 16.9 39.9053 0
+      vertex 16.5279 39.6349 1
+      vertex 16.9 39.9053 1
+    endloop
+  endfacet
+  facet normal -0.587861 0.808962 0
+    outer loop
+      vertex 16.5279 39.6349 1
+      vertex 16.9 39.9053 0
+      vertex 16.5279 39.6349 0
+    endloop
+  endfacet
+  facet normal -0.207895 0.978151 0
+    outer loop
+      vertex 17.77 40.1879 0
+      vertex 17.3202 40.0923 1
+      vertex 17.77 40.1879 1
+    endloop
+  endfacet
+  facet normal -0.207895 0.978151 0
+    outer loop
+      vertex 17.3202 40.0923 1
+      vertex 17.77 40.1879 0
+      vertex 17.3202 40.0923 0
+    endloop
+  endfacet
+  facet normal 0.865986 -0.500067 0
+    outer loop
+      vertex 19.7798 36.7069 1
+      vertex 20.0098 37.1052 0
+      vertex 20.0098 37.1052 1
+    endloop
+  endfacet
+  facet normal 0.865986 -0.500067 0
+    outer loop
+      vertex 20.0098 37.1052 0
+      vertex 19.7798 36.7069 1
+      vertex 19.7798 36.7069 0
+    endloop
+  endfacet
+  facet normal 0.865986 0.500067 0
+    outer loop
+      vertex 20.0098 38.8948 1
+      vertex 19.7798 39.2931 0
+      vertex 19.7798 39.2931 1
+    endloop
+  endfacet
+  facet normal 0.865986 0.500067 0
+    outer loop
+      vertex 19.7798 39.2931 0
+      vertex 20.0098 38.8948 1
+      vertex 20.0098 38.8948 0
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 -0
+    outer loop
+      vertex 19.1 39.9053 0
+      vertex 18.6798 40.0923 1
+      vertex 19.1 39.9053 1
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 0
+    outer loop
+      vertex 18.6798 40.0923 1
+      vertex 19.1 39.9053 0
+      vertex 18.6798 40.0923 0
+    endloop
+  endfacet
+  facet normal 0.207895 0.978151 -0
+    outer loop
+      vertex 18.6798 40.0923 0
+      vertex 18.23 40.1879 1
+      vertex 18.6798 40.0923 1
+    endloop
+  endfacet
+  facet normal 0.207895 0.978151 0
+    outer loop
+      vertex 18.23 40.1879 1
+      vertex 18.6798 40.0923 0
+      vertex 18.23 40.1879 0
+    endloop
+  endfacet
+  facet normal 0.587861 0.808962 -0
+    outer loop
+      vertex 19.4721 39.6349 0
+      vertex 19.1 39.9053 1
+      vertex 19.4721 39.6349 1
+    endloop
+  endfacet
+  facet normal 0.587861 0.808962 0
+    outer loop
+      vertex 19.1 39.9053 1
+      vertex 19.4721 39.6349 0
+      vertex 19.1 39.9053 0
+    endloop
+  endfacet
+  facet normal -0.865986 0.500067 0
+    outer loop
+      vertex 15.9902 38.8948 0
+      vertex 16.2202 39.2931 1
+      vertex 16.2202 39.2931 0
+    endloop
+  endfacet
+  facet normal -0.865986 0.500067 0
+    outer loop
+      vertex 16.2202 39.2931 1
+      vertex 15.9902 38.8948 0
+      vertex 15.9902 38.8948 1
+    endloop
+  endfacet
+  facet normal -0.743208 0.669061 0
+    outer loop
+      vertex 16.2202 39.2931 0
+      vertex 16.5279 39.6349 1
+      vertex 16.5279 39.6349 0
+    endloop
+  endfacet
+  facet normal -0.743208 0.669061 0
+    outer loop
+      vertex 16.5279 39.6349 1
+      vertex 16.2202 39.2931 0
+      vertex 16.2202 39.2931 1
+    endloop
+  endfacet
+  facet normal -0.951069 0.308978 0
+    outer loop
+      vertex 15.8481 38.4574 0
+      vertex 15.9902 38.8948 1
+      vertex 15.9902 38.8948 0
+    endloop
+  endfacet
+  facet normal -0.951069 0.308978 0
+    outer loop
+      vertex 15.9902 38.8948 1
+      vertex 15.8481 38.4574 0
+      vertex 15.8481 38.4574 1
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex 17.3202 40.0923 0
+      vertex 16.9 39.9053 1
+      vertex 17.3202 40.0923 1
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex 16.9 39.9053 1
+      vertex 17.3202 40.0923 0
+      vertex 16.9 39.9053 0
+    endloop
+  endfacet
+  facet normal 0.994516 -0.104583 0
+    outer loop
+      vertex 20.1519 37.5426 1
+      vertex 20.2 38 0
+      vertex 20.2 38 1
+    endloop
+  endfacet
+  facet normal 0.994516 -0.104583 0
+    outer loop
+      vertex 20.2 38 0
+      vertex 20.1519 37.5426 1
+      vertex 20.1519 37.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19 38 0
+      vertex 20.2 38 0
+      vertex 20.1519 37.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9781 37.7921 0
+      vertex 20.1519 37.5426 0
+      vertex 20.0098 37.1052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.2 38 0
+      vertex 19 38 0
+      vertex 20.1519 38.4574 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9135 37.5933 0
+      vertex 20.0098 37.1052 0
+      vertex 19.7798 36.7069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9781 38.2079 0
+      vertex 20.1519 38.4574 0
+      vertex 19 38 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.809 37.4122 0
+      vertex 19.7798 36.7069 0
+      vertex 19.4721 36.3651 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.1519 38.4574 0
+      vertex 18.9781 38.2079 0
+      vertex 20.0098 38.8948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6691 37.2569 0
+      vertex 19.4721 36.3651 0
+      vertex 19.1 36.0947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9135 38.4067 0
+      vertex 20.0098 38.8948 0
+      vertex 18.9781 38.2079 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.0098 38.8948 0
+      vertex 18.9135 38.4067 0
+      vertex 19.7798 39.2931 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1519 37.5426 0
+      vertex 18.9781 37.7921 0
+      vertex 19 38 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.0098 37.1052 0
+      vertex 18.9135 37.5933 0
+      vertex 18.9781 37.7921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7798 36.7069 0
+      vertex 18.809 37.4122 0
+      vertex 18.9135 37.5933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 37.134 0
+      vertex 19.1 36.0947 0
+      vertex 18.6798 35.9077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.4721 36.3651 0
+      vertex 18.6691 37.2569 0
+      vertex 18.809 37.4122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.1 36.0947 0
+      vertex 18.5 37.134 0
+      vertex 18.6691 37.2569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6798 35.9077 0
+      vertex 18.309 37.0489 0
+      vertex 18.5 37.134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.23 35.8121 0
+      vertex 18.309 37.0489 0
+      vertex 18.6798 35.9077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.23 35.8121 0
+      vertex 18.1045 37.0055 0
+      vertex 18.309 37.0489 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.23 35.8121 0
+      vertex 17.8955 37.0055 0
+      vertex 18.1045 37.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.77 35.8121 0
+      vertex 17.8955 37.0055 0
+      vertex 18.23 35.8121 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.77 35.8121 0
+      vertex 17.691 37.0489 0
+      vertex 17.8955 37.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3202 35.9077 0
+      vertex 17.691 37.0489 0
+      vertex 17.77 35.8121 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.691 37.0489 0
+      vertex 17.3202 35.9077 0
+      vertex 17.5 37.134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.9 36.0947 0
+      vertex 17.5 37.134 0
+      vertex 17.3202 35.9077 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.5 37.134 0
+      vertex 16.9 36.0947 0
+      vertex 17.3309 37.2569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5279 36.3651 0
+      vertex 17.3309 37.2569 0
+      vertex 16.9 36.0947 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.3309 37.2569 0
+      vertex 16.5279 36.3651 0
+      vertex 17.191 37.4122 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.191 37.4122 0
+      vertex 16.2202 36.7069 0
+      vertex 17.0865 37.5933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.2202 36.7069 0
+      vertex 17.191 37.4122 0
+      vertex 16.5279 36.3651 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.809 38.5878 0
+      vertex 19.7798 39.2931 0
+      vertex 18.9135 38.4067 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.7798 39.2931 0
+      vertex 18.809 38.5878 0
+      vertex 19.4721 39.6349 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6691 38.7431 0
+      vertex 19.4721 39.6349 0
+      vertex 18.809 38.5878 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.4721 39.6349 0
+      vertex 18.6691 38.7431 0
+      vertex 19.1 39.9053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 38.866 0
+      vertex 19.1 39.9053 0
+      vertex 18.6691 38.7431 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.1 39.9053 0
+      vertex 18.5 38.866 0
+      vertex 18.6798 40.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.309 38.9511 0
+      vertex 18.6798 40.0923 0
+      vertex 18.5 38.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.309 38.9511 0
+      vertex 18.23 40.1879 0
+      vertex 18.6798 40.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.1045 38.9945 0
+      vertex 18.23 40.1879 0
+      vertex 18.309 38.9511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8955 38.9945 0
+      vertex 18.23 40.1879 0
+      vertex 18.1045 38.9945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8955 38.9945 0
+      vertex 17.77 40.1879 0
+      vertex 18.23 40.1879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.691 38.9511 0
+      vertex 17.77 40.1879 0
+      vertex 17.8955 38.9945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3202 40.0923 0
+      vertex 17.691 38.9511 0
+      vertex 17.5 38.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.9 39.9053 0
+      vertex 17.5 38.866 0
+      vertex 17.3309 38.7431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.691 38.9511 0
+      vertex 17.3202 40.0923 0
+      vertex 17.77 40.1879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5279 39.6349 0
+      vertex 17.3309 38.7431 0
+      vertex 17.191 38.5878 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.2202 39.2931 0
+      vertex 17.191 38.5878 0
+      vertex 17.0865 38.4067 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9902 38.8948 0
+      vertex 17.0865 38.4067 0
+      vertex 17.0219 38.2079 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5 38.866 0
+      vertex 16.9 39.9053 0
+      vertex 17.3202 40.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8481 38.4574 0
+      vertex 17.0219 38.2079 0
+      vertex 17 38 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9902 37.1052 0
+      vertex 17.0865 37.5933 0
+      vertex 16.2202 36.7069 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.0865 37.5933 0
+      vertex 15.9902 37.1052 0
+      vertex 17.0219 37.7921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3309 38.7431 0
+      vertex 16.5279 39.6349 0
+      vertex 16.9 39.9053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8481 37.5426 0
+      vertex 17.0219 37.7921 0
+      vertex 15.9902 37.1052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.191 38.5878 0
+      vertex 16.2202 39.2931 0
+      vertex 16.5279 39.6349 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.0219 37.7921 0
+      vertex 15.8481 37.5426 0
+      vertex 17 38 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0865 38.4067 0
+      vertex 15.9902 38.8948 0
+      vertex 16.2202 39.2931 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8 38 0
+      vertex 17 38 0
+      vertex 15.8481 37.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0219 38.2079 0
+      vertex 15.8481 38.4574 0
+      vertex 15.9902 38.8948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17 38 0
+      vertex 15.8 38 0
+      vertex 15.8481 38.4574 0
+    endloop
+  endfacet
+  facet normal 0.207895 -0.978151 0
+    outer loop
+      vertex 18.23 35.8121 0
+      vertex 18.6798 35.9077 1
+      vertex 18.23 35.8121 1
+    endloop
+  endfacet
+  facet normal 0.207895 -0.978151 0
+    outer loop
+      vertex 18.6798 35.9077 1
+      vertex 18.23 35.8121 0
+      vertex 18.6798 35.9077 0
+    endloop
+  endfacet
+  facet normal 0.587861 -0.808962 0
+    outer loop
+      vertex 19.1 36.0947 0
+      vertex 19.4721 36.3651 1
+      vertex 19.1 36.0947 1
+    endloop
+  endfacet
+  facet normal 0.587861 -0.808962 0
+    outer loop
+      vertex 19.4721 36.3651 1
+      vertex 19.1 36.0947 0
+      vertex 19.4721 36.3651 0
+    endloop
+  endfacet
+  facet normal 0.743208 -0.669061 0
+    outer loop
+      vertex 19.4721 36.3651 1
+      vertex 19.7798 36.7069 0
+      vertex 19.7798 36.7069 1
+    endloop
+  endfacet
+  facet normal 0.743208 -0.669061 0
+    outer loop
+      vertex 19.7798 36.7069 0
+      vertex 19.4721 36.3651 1
+      vertex 19.4721 36.3651 0
+    endloop
+  endfacet
+  facet normal 0.951069 -0.308978 0
+    outer loop
+      vertex 20.0098 37.1052 1
+      vertex 20.1519 37.5426 0
+      vertex 20.1519 37.5426 1
+    endloop
+  endfacet
+  facet normal 0.951069 -0.308978 0
+    outer loop
+      vertex 20.1519 37.5426 0
+      vertex 20.0098 37.1052 1
+      vertex 20.0098 37.1052 0
+    endloop
+  endfacet
+  facet normal -0.587861 -0.808962 0
+    outer loop
+      vertex 16.5279 36.3651 0
+      vertex 16.9 36.0947 1
+      vertex 16.5279 36.3651 1
+    endloop
+  endfacet
+  facet normal -0.587861 -0.808962 -0
+    outer loop
+      vertex 16.9 36.0947 1
+      vertex 16.5279 36.3651 0
+      vertex 16.9 36.0947 0
+    endloop
+  endfacet
+  facet normal -0.865986 -0.500067 0
+    outer loop
+      vertex 16.2202 36.7069 0
+      vertex 15.9902 37.1052 1
+      vertex 15.9902 37.1052 0
+    endloop
+  endfacet
+  facet normal -0.865986 -0.500067 0
+    outer loop
+      vertex 15.9902 37.1052 1
+      vertex 16.2202 36.7069 0
+      vertex 16.2202 36.7069 1
+    endloop
+  endfacet
+  facet normal -0.743208 -0.669061 0
+    outer loop
+      vertex 16.5279 36.3651 0
+      vertex 16.2202 36.7069 1
+      vertex 16.2202 36.7069 0
+    endloop
+  endfacet
+  facet normal -0.743208 -0.669061 0
+    outer loop
+      vertex 16.2202 36.7069 1
+      vertex 16.5279 36.3651 0
+      vertex 16.5279 36.3651 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex 18.6798 35.9077 0
+      vertex 19.1 36.0947 1
+      vertex 18.6798 35.9077 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex 19.1 36.0947 1
+      vertex 18.6798 35.9077 0
+      vertex 19.1 36.0947 0
+    endloop
+  endfacet
+  facet normal -0.207895 -0.978151 0
+    outer loop
+      vertex 17.3202 35.9077 0
+      vertex 17.77 35.8121 1
+      vertex 17.3202 35.9077 1
+    endloop
+  endfacet
+  facet normal -0.207895 -0.978151 -0
+    outer loop
+      vertex 17.77 35.8121 1
+      vertex 17.3202 35.9077 0
+      vertex 17.77 35.8121 0
+    endloop
+  endfacet
+  facet normal -0.951069 -0.308978 0
+    outer loop
+      vertex 15.9902 37.1052 0
+      vertex 15.8481 37.5426 1
+      vertex 15.8481 37.5426 0
+    endloop
+  endfacet
+  facet normal -0.951069 -0.308978 0
+    outer loop
+      vertex 15.8481 37.5426 1
+      vertex 15.9902 37.1052 0
+      vertex 15.9902 37.1052 1
+    endloop
+  endfacet
+  facet normal -0.994516 -0.104583 0
+    outer loop
+      vertex 15.8481 37.5426 0
+      vertex 15.8 38 1
+      vertex 15.8 38 0
+    endloop
+  endfacet
+  facet normal -0.994516 -0.104583 0
+    outer loop
+      vertex 15.8 38 1
+      vertex 15.8481 37.5426 0
+      vertex 15.8481 37.5426 1
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 0
+    outer loop
+      vertex 16.9 36.0947 0
+      vertex 17.3202 35.9077 1
+      vertex 16.9 36.0947 1
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 -0
+    outer loop
+      vertex 17.3202 35.9077 1
+      vertex 16.9 36.0947 0
+      vertex 17.3202 35.9077 0
+    endloop
+  endfacet
+  facet normal -0.994498 -0.104759 0
+    outer loop
+      vertex 19 38 0
+      vertex 18.9781 38.2079 1
+      vertex 18.9781 38.2079 0
+    endloop
+  endfacet
+  facet normal -0.994498 -0.104759 0
+    outer loop
+      vertex 18.9781 38.2079 1
+      vertex 19 38 0
+      vertex 19 38 1
+    endloop
+  endfacet
+  facet normal 0.994498 -0.104759 0
+    outer loop
+      vertex 17 38 1
+      vertex 17.0219 38.2079 0
+      vertex 17.0219 38.2079 1
+    endloop
+  endfacet
+  facet normal 0.994498 -0.104759 0
+    outer loop
+      vertex 17.0219 38.2079 0
+      vertex 17 38 1
+      vertex 17 38 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 17.8955 38.9945 0
+      vertex 18.1045 38.9945 1
+      vertex 17.8955 38.9945 1
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.1045 38.9945 1
+      vertex 17.8955 38.9945 0
+      vertex 18.1045 38.9945 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.1045 37.0055 0
+      vertex 17.8955 37.0055 1
+      vertex 18.1045 37.0055 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.8955 37.0055 1
+      vertex 18.1045 37.0055 0
+      vertex 17.8955 37.0055 0
+    endloop
+  endfacet
+  facet normal -0.587916 -0.808922 0
+    outer loop
+      vertex 18.5 38.866 0
+      vertex 18.6691 38.7431 1
+      vertex 18.5 38.866 1
+    endloop
+  endfacet
+  facet normal -0.587916 -0.808922 -0
+    outer loop
+      vertex 18.6691 38.7431 1
+      vertex 18.5 38.866 0
+      vertex 18.6691 38.7431 0
+    endloop
+  endfacet
+  facet normal -0.406981 -0.913436 0
+    outer loop
+      vertex 18.309 38.9511 0
+      vertex 18.5 38.866 1
+      vertex 18.309 38.9511 1
+    endloop
+  endfacet
+  facet normal -0.406981 -0.913436 -0
+    outer loop
+      vertex 18.5 38.866 1
+      vertex 18.309 38.9511 0
+      vertex 18.5 38.866 0
+    endloop
+  endfacet
+  facet normal 0.587916 -0.808922 0
+    outer loop
+      vertex 17.3309 38.7431 0
+      vertex 17.5 38.866 1
+      vertex 17.3309 38.7431 1
+    endloop
+  endfacet
+  facet normal 0.587916 -0.808922 0
+    outer loop
+      vertex 17.5 38.866 1
+      vertex 17.3309 38.7431 0
+      vertex 17.5 38.866 0
+    endloop
+  endfacet
+  facet normal 0.207601 -0.978214 0
+    outer loop
+      vertex 17.691 38.9511 0
+      vertex 17.8955 38.9945 1
+      vertex 17.691 38.9511 1
+    endloop
+  endfacet
+  facet normal 0.207601 -0.978214 0
+    outer loop
+      vertex 17.8955 38.9945 1
+      vertex 17.691 38.9511 0
+      vertex 17.8955 38.9945 0
+    endloop
+  endfacet
+  facet normal -0.866146 -0.499791 0
+    outer loop
+      vertex 18.9135 38.4067 0
+      vertex 18.809 38.5878 1
+      vertex 18.809 38.5878 0
+    endloop
+  endfacet
+  facet normal -0.866146 -0.499791 0
+    outer loop
+      vertex 18.809 38.5878 1
+      vertex 18.9135 38.4067 0
+      vertex 18.9135 38.4067 1
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309043 0
+    outer loop
+      vertex 18.9781 38.2079 0
+      vertex 18.9135 38.4067 1
+      vertex 18.9135 38.4067 0
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309043 0
+    outer loop
+      vertex 18.9135 38.4067 1
+      vertex 18.9781 38.2079 0
+      vertex 18.9781 38.2079 1
+    endloop
+  endfacet
+  facet normal -0.742985 -0.669308 0
+    outer loop
+      vertex 18.809 38.5878 0
+      vertex 18.6691 38.7431 1
+      vertex 18.6691 38.7431 0
+    endloop
+  endfacet
+  facet normal -0.742985 -0.669308 0
+    outer loop
+      vertex 18.6691 38.7431 1
+      vertex 18.809 38.5878 0
+      vertex 18.809 38.5878 1
+    endloop
+  endfacet
+  facet normal -0.207601 -0.978214 0
+    outer loop
+      vertex 18.1045 38.9945 0
+      vertex 18.309 38.9511 1
+      vertex 18.1045 38.9945 1
+    endloop
+  endfacet
+  facet normal -0.207601 -0.978214 -0
+    outer loop
+      vertex 18.309 38.9511 1
+      vertex 18.1045 38.9945 0
+      vertex 18.309 38.9511 0
+    endloop
+  endfacet
+  facet normal 0.866146 -0.499791 0
+    outer loop
+      vertex 17.0865 38.4067 1
+      vertex 17.191 38.5878 0
+      vertex 17.191 38.5878 1
+    endloop
+  endfacet
+  facet normal 0.866146 -0.499791 0
+    outer loop
+      vertex 17.191 38.5878 0
+      vertex 17.0865 38.4067 1
+      vertex 17.0865 38.4067 0
+    endloop
+  endfacet
+  facet normal 0.742985 -0.669308 0
+    outer loop
+      vertex 17.191 38.5878 1
+      vertex 17.3309 38.7431 0
+      vertex 17.3309 38.7431 1
+    endloop
+  endfacet
+  facet normal 0.742985 -0.669308 0
+    outer loop
+      vertex 17.3309 38.7431 0
+      vertex 17.191 38.5878 1
+      vertex 17.191 38.5878 0
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309043 0
+    outer loop
+      vertex 17.0219 38.2079 1
+      vertex 17.0865 38.4067 0
+      vertex 17.0865 38.4067 1
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309043 0
+    outer loop
+      vertex 17.0865 38.4067 0
+      vertex 17.0219 38.2079 1
+      vertex 17.0219 38.2079 0
+    endloop
+  endfacet
+  facet normal 0.406981 -0.913436 0
+    outer loop
+      vertex 17.5 38.866 0
+      vertex 17.691 38.9511 1
+      vertex 17.5 38.866 1
+    endloop
+  endfacet
+  facet normal 0.406981 -0.913436 0
+    outer loop
+      vertex 17.691 38.9511 1
+      vertex 17.5 38.866 0
+      vertex 17.691 38.9511 0
+    endloop
+  endfacet
+  facet normal -0.994498 0.104759 0
+    outer loop
+      vertex 18.9781 37.7921 0
+      vertex 19 38 1
+      vertex 19 38 0
+    endloop
+  endfacet
+  facet normal -0.994498 0.104759 0
+    outer loop
+      vertex 19 38 1
+      vertex 18.9781 37.7921 0
+      vertex 18.9781 37.7921 1
+    endloop
+  endfacet
+  facet normal -0.207601 0.978214 0
+    outer loop
+      vertex 18.309 37.0489 0
+      vertex 18.1045 37.0055 1
+      vertex 18.309 37.0489 1
+    endloop
+  endfacet
+  facet normal -0.207601 0.978214 0
+    outer loop
+      vertex 18.1045 37.0055 1
+      vertex 18.309 37.0489 0
+      vertex 18.1045 37.0055 0
+    endloop
+  endfacet
+  facet normal -0.742985 0.669308 0
+    outer loop
+      vertex 18.6691 37.2569 0
+      vertex 18.809 37.4122 1
+      vertex 18.809 37.4122 0
+    endloop
+  endfacet
+  facet normal -0.742985 0.669308 0
+    outer loop
+      vertex 18.809 37.4122 1
+      vertex 18.6691 37.2569 0
+      vertex 18.6691 37.2569 1
+    endloop
+  endfacet
+  facet normal -0.951048 0.309043 0
+    outer loop
+      vertex 18.9135 37.5933 0
+      vertex 18.9781 37.7921 1
+      vertex 18.9781 37.7921 0
+    endloop
+  endfacet
+  facet normal -0.951048 0.309043 0
+    outer loop
+      vertex 18.9781 37.7921 1
+      vertex 18.9135 37.5933 0
+      vertex 18.9135 37.5933 1
+    endloop
+  endfacet
+  facet normal -0.866146 0.499791 0
+    outer loop
+      vertex 18.809 37.4122 0
+      vertex 18.9135 37.5933 1
+      vertex 18.9135 37.5933 0
+    endloop
+  endfacet
+  facet normal -0.866146 0.499791 0
+    outer loop
+      vertex 18.9135 37.5933 1
+      vertex 18.809 37.4122 0
+      vertex 18.809 37.4122 1
+    endloop
+  endfacet
+  facet normal 0.406981 0.913436 -0
+    outer loop
+      vertex 17.691 37.0489 0
+      vertex 17.5 37.134 1
+      vertex 17.691 37.0489 1
+    endloop
+  endfacet
+  facet normal 0.406981 0.913436 0
+    outer loop
+      vertex 17.5 37.134 1
+      vertex 17.691 37.0489 0
+      vertex 17.5 37.134 0
+    endloop
+  endfacet
+  facet normal 0.866146 0.499791 0
+    outer loop
+      vertex 17.191 37.4122 1
+      vertex 17.0865 37.5933 0
+      vertex 17.0865 37.5933 1
+    endloop
+  endfacet
+  facet normal 0.866146 0.499791 0
+    outer loop
+      vertex 17.0865 37.5933 0
+      vertex 17.191 37.4122 1
+      vertex 17.191 37.4122 0
+    endloop
+  endfacet
+  facet normal -0.587916 0.808922 0
+    outer loop
+      vertex 18.6691 37.2569 0
+      vertex 18.5 37.134 1
+      vertex 18.6691 37.2569 1
+    endloop
+  endfacet
+  facet normal -0.587916 0.808922 0
+    outer loop
+      vertex 18.5 37.134 1
+      vertex 18.6691 37.2569 0
+      vertex 18.5 37.134 0
+    endloop
+  endfacet
+  facet normal -0.406981 0.913436 0
+    outer loop
+      vertex 18.5 37.134 0
+      vertex 18.309 37.0489 1
+      vertex 18.5 37.134 1
+    endloop
+  endfacet
+  facet normal -0.406981 0.913436 0
+    outer loop
+      vertex 18.309 37.0489 1
+      vertex 18.5 37.134 0
+      vertex 18.309 37.0489 0
+    endloop
+  endfacet
+  facet normal 0.207601 0.978214 -0
+    outer loop
+      vertex 17.8955 37.0055 0
+      vertex 17.691 37.0489 1
+      vertex 17.8955 37.0055 1
+    endloop
+  endfacet
+  facet normal 0.207601 0.978214 0
+    outer loop
+      vertex 17.691 37.0489 1
+      vertex 17.8955 37.0055 0
+      vertex 17.691 37.0489 0
+    endloop
+  endfacet
+  facet normal 0.587916 0.808922 -0
+    outer loop
+      vertex 17.5 37.134 0
+      vertex 17.3309 37.2569 1
+      vertex 17.5 37.134 1
+    endloop
+  endfacet
+  facet normal 0.587916 0.808922 0
+    outer loop
+      vertex 17.3309 37.2569 1
+      vertex 17.5 37.134 0
+      vertex 17.3309 37.2569 0
+    endloop
+  endfacet
+  facet normal 0.742985 0.669308 0
+    outer loop
+      vertex 17.3309 37.2569 1
+      vertex 17.191 37.4122 0
+      vertex 17.191 37.4122 1
+    endloop
+  endfacet
+  facet normal 0.742985 0.669308 0
+    outer loop
+      vertex 17.191 37.4122 0
+      vertex 17.3309 37.2569 1
+      vertex 17.3309 37.2569 0
+    endloop
+  endfacet
+  facet normal 0.951048 0.309043 0
+    outer loop
+      vertex 17.0865 37.5933 1
+      vertex 17.0219 37.7921 0
+      vertex 17.0219 37.7921 1
+    endloop
+  endfacet
+  facet normal 0.951048 0.309043 0
+    outer loop
+      vertex 17.0219 37.7921 0
+      vertex 17.0865 37.5933 1
+      vertex 17.0865 37.5933 0
+    endloop
+  endfacet
+  facet normal 0.994498 0.104759 0
+    outer loop
+      vertex 17.0219 37.7921 1
+      vertex 17 38 0
+      vertex 17 38 1
+    endloop
+  endfacet
+  facet normal 0.994498 0.104759 0
+    outer loop
+      vertex 17 38 0
+      vertex 17.0219 37.7921 1
+      vertex 17.0219 37.7921 0
+    endloop
+  endfacet
+  facet normal 0.994516 0.104583 0
+    outer loop
+      vertex 20.2 22 1
+      vertex 20.1519 22.4574 0
+      vertex 20.1519 22.4574 1
+    endloop
+  endfacet
+  facet normal 0.994516 0.104583 0
+    outer loop
+      vertex 20.1519 22.4574 0
+      vertex 20.2 22 1
+      vertex 20.2 22 0
+    endloop
+  endfacet
+  facet normal -0.994516 0.104583 0
+    outer loop
+      vertex 15.8 22 0
+      vertex 15.8481 22.4574 1
+      vertex 15.8481 22.4574 0
+    endloop
+  endfacet
+  facet normal -0.994516 0.104583 0
+    outer loop
+      vertex 15.8481 22.4574 1
+      vertex 15.8 22 0
+      vertex 15.8 22 1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.23 24.1879 0
+      vertex 17.77 24.1879 1
+      vertex 18.23 24.1879 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.77 24.1879 1
+      vertex 18.23 24.1879 0
+      vertex 17.77 24.1879 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 17.77 19.8121 0
+      vertex 18.23 19.8121 1
+      vertex 17.77 19.8121 1
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.23 19.8121 1
+      vertex 17.77 19.8121 0
+      vertex 18.23 19.8121 0
+    endloop
+  endfacet
+  facet normal 0.743208 0.669061 0
+    outer loop
+      vertex 19.7798 23.2931 1
+      vertex 19.4721 23.6349 0
+      vertex 19.4721 23.6349 1
+    endloop
+  endfacet
+  facet normal 0.743208 0.669061 0
+    outer loop
+      vertex 19.4721 23.6349 0
+      vertex 19.7798 23.2931 1
+      vertex 19.7798 23.2931 0
+    endloop
+  endfacet
+  facet normal 0.951069 0.308978 0
+    outer loop
+      vertex 20.1519 22.4574 1
+      vertex 20.0098 22.8948 0
+      vertex 20.0098 22.8948 1
+    endloop
+  endfacet
+  facet normal 0.951069 0.308978 0
+    outer loop
+      vertex 20.0098 22.8948 0
+      vertex 20.1519 22.4574 1
+      vertex 20.1519 22.4574 0
+    endloop
+  endfacet
+  facet normal -0.587861 0.808962 0
+    outer loop
+      vertex 16.9 23.9053 0
+      vertex 16.5279 23.6349 1
+      vertex 16.9 23.9053 1
+    endloop
+  endfacet
+  facet normal -0.587861 0.808962 0
+    outer loop
+      vertex 16.5279 23.6349 1
+      vertex 16.9 23.9053 0
+      vertex 16.5279 23.6349 0
+    endloop
+  endfacet
+  facet normal -0.207895 0.978151 0
+    outer loop
+      vertex 17.77 24.1879 0
+      vertex 17.3202 24.0923 1
+      vertex 17.77 24.1879 1
+    endloop
+  endfacet
+  facet normal -0.207895 0.978151 0
+    outer loop
+      vertex 17.3202 24.0923 1
+      vertex 17.77 24.1879 0
+      vertex 17.3202 24.0923 0
+    endloop
+  endfacet
+  facet normal 0.865986 -0.500067 0
+    outer loop
+      vertex 19.7798 20.7069 1
+      vertex 20.0098 21.1052 0
+      vertex 20.0098 21.1052 1
+    endloop
+  endfacet
+  facet normal 0.865986 -0.500067 0
+    outer loop
+      vertex 20.0098 21.1052 0
+      vertex 19.7798 20.7069 1
+      vertex 19.7798 20.7069 0
+    endloop
+  endfacet
+  facet normal 0.865986 0.500067 0
+    outer loop
+      vertex 20.0098 22.8948 1
+      vertex 19.7798 23.2931 0
+      vertex 19.7798 23.2931 1
+    endloop
+  endfacet
+  facet normal 0.865986 0.500067 0
+    outer loop
+      vertex 19.7798 23.2931 0
+      vertex 20.0098 22.8948 1
+      vertex 20.0098 22.8948 0
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 -0
+    outer loop
+      vertex 19.1 23.9053 0
+      vertex 18.6798 24.0923 1
+      vertex 19.1 23.9053 1
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 0
+    outer loop
+      vertex 18.6798 24.0923 1
+      vertex 19.1 23.9053 0
+      vertex 18.6798 24.0923 0
+    endloop
+  endfacet
+  facet normal 0.207895 0.978151 -0
+    outer loop
+      vertex 18.6798 24.0923 0
+      vertex 18.23 24.1879 1
+      vertex 18.6798 24.0923 1
+    endloop
+  endfacet
+  facet normal 0.207895 0.978151 0
+    outer loop
+      vertex 18.23 24.1879 1
+      vertex 18.6798 24.0923 0
+      vertex 18.23 24.1879 0
+    endloop
+  endfacet
+  facet normal 0.587861 0.808962 -0
+    outer loop
+      vertex 19.4721 23.6349 0
+      vertex 19.1 23.9053 1
+      vertex 19.4721 23.6349 1
+    endloop
+  endfacet
+  facet normal 0.587861 0.808962 0
+    outer loop
+      vertex 19.1 23.9053 1
+      vertex 19.4721 23.6349 0
+      vertex 19.1 23.9053 0
+    endloop
+  endfacet
+  facet normal -0.865986 0.500067 0
+    outer loop
+      vertex 15.9902 22.8948 0
+      vertex 16.2202 23.2931 1
+      vertex 16.2202 23.2931 0
+    endloop
+  endfacet
+  facet normal -0.865986 0.500067 0
+    outer loop
+      vertex 16.2202 23.2931 1
+      vertex 15.9902 22.8948 0
+      vertex 15.9902 22.8948 1
+    endloop
+  endfacet
+  facet normal -0.743208 0.669061 0
+    outer loop
+      vertex 16.2202 23.2931 0
+      vertex 16.5279 23.6349 1
+      vertex 16.5279 23.6349 0
+    endloop
+  endfacet
+  facet normal -0.743208 0.669061 0
+    outer loop
+      vertex 16.5279 23.6349 1
+      vertex 16.2202 23.2931 0
+      vertex 16.2202 23.2931 1
+    endloop
+  endfacet
+  facet normal -0.951069 0.308978 0
+    outer loop
+      vertex 15.8481 22.4574 0
+      vertex 15.9902 22.8948 1
+      vertex 15.9902 22.8948 0
+    endloop
+  endfacet
+  facet normal -0.951069 0.308978 0
+    outer loop
+      vertex 15.9902 22.8948 1
+      vertex 15.8481 22.4574 0
+      vertex 15.8481 22.4574 1
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex 17.3202 24.0923 0
+      vertex 16.9 23.9053 1
+      vertex 17.3202 24.0923 1
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex 16.9 23.9053 1
+      vertex 17.3202 24.0923 0
+      vertex 16.9 23.9053 0
+    endloop
+  endfacet
+  facet normal 0.994516 -0.104583 0
+    outer loop
+      vertex 20.1519 21.5426 1
+      vertex 20.2 22 0
+      vertex 20.2 22 1
+    endloop
+  endfacet
+  facet normal 0.994516 -0.104583 0
+    outer loop
+      vertex 20.2 22 0
+      vertex 20.1519 21.5426 1
+      vertex 20.1519 21.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19 22 0
+      vertex 20.2 22 0
+      vertex 20.1519 21.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9781 21.7921 0
+      vertex 20.1519 21.5426 0
+      vertex 20.0098 21.1052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.2 22 0
+      vertex 19 22 0
+      vertex 20.1519 22.4574 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9135 21.5933 0
+      vertex 20.0098 21.1052 0
+      vertex 19.7798 20.7069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9781 22.2079 0
+      vertex 20.1519 22.4574 0
+      vertex 19 22 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.809 21.4122 0
+      vertex 19.7798 20.7069 0
+      vertex 19.4721 20.3651 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.1519 22.4574 0
+      vertex 18.9781 22.2079 0
+      vertex 20.0098 22.8948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6691 21.2569 0
+      vertex 19.4721 20.3651 0
+      vertex 19.1 20.0947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9135 22.4067 0
+      vertex 20.0098 22.8948 0
+      vertex 18.9781 22.2079 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.0098 22.8948 0
+      vertex 18.9135 22.4067 0
+      vertex 19.7798 23.2931 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1519 21.5426 0
+      vertex 18.9781 21.7921 0
+      vertex 19 22 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.0098 21.1052 0
+      vertex 18.9135 21.5933 0
+      vertex 18.9781 21.7921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7798 20.7069 0
+      vertex 18.809 21.4122 0
+      vertex 18.9135 21.5933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 21.134 0
+      vertex 19.1 20.0947 0
+      vertex 18.6798 19.9077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.4721 20.3651 0
+      vertex 18.6691 21.2569 0
+      vertex 18.809 21.4122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.1 20.0947 0
+      vertex 18.5 21.134 0
+      vertex 18.6691 21.2569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6798 19.9077 0
+      vertex 18.309 21.0489 0
+      vertex 18.5 21.134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.23 19.8121 0
+      vertex 18.309 21.0489 0
+      vertex 18.6798 19.9077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.23 19.8121 0
+      vertex 18.1045 21.0055 0
+      vertex 18.309 21.0489 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.23 19.8121 0
+      vertex 17.8955 21.0055 0
+      vertex 18.1045 21.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.77 19.8121 0
+      vertex 17.8955 21.0055 0
+      vertex 18.23 19.8121 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.77 19.8121 0
+      vertex 17.691 21.0489 0
+      vertex 17.8955 21.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3202 19.9077 0
+      vertex 17.691 21.0489 0
+      vertex 17.77 19.8121 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.691 21.0489 0
+      vertex 17.3202 19.9077 0
+      vertex 17.5 21.134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.9 20.0947 0
+      vertex 17.5 21.134 0
+      vertex 17.3202 19.9077 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.5 21.134 0
+      vertex 16.9 20.0947 0
+      vertex 17.3309 21.2569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5279 20.3651 0
+      vertex 17.3309 21.2569 0
+      vertex 16.9 20.0947 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.3309 21.2569 0
+      vertex 16.5279 20.3651 0
+      vertex 17.191 21.4122 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.191 21.4122 0
+      vertex 16.2202 20.7069 0
+      vertex 17.0865 21.5933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.2202 20.7069 0
+      vertex 17.191 21.4122 0
+      vertex 16.5279 20.3651 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.809 22.5878 0
+      vertex 19.7798 23.2931 0
+      vertex 18.9135 22.4067 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.7798 23.2931 0
+      vertex 18.809 22.5878 0
+      vertex 19.4721 23.6349 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6691 22.7431 0
+      vertex 19.4721 23.6349 0
+      vertex 18.809 22.5878 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.4721 23.6349 0
+      vertex 18.6691 22.7431 0
+      vertex 19.1 23.9053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 22.866 0
+      vertex 19.1 23.9053 0
+      vertex 18.6691 22.7431 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.1 23.9053 0
+      vertex 18.5 22.866 0
+      vertex 18.6798 24.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.309 22.9511 0
+      vertex 18.6798 24.0923 0
+      vertex 18.5 22.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.309 22.9511 0
+      vertex 18.23 24.1879 0
+      vertex 18.6798 24.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.1045 22.9945 0
+      vertex 18.23 24.1879 0
+      vertex 18.309 22.9511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8955 22.9945 0
+      vertex 18.23 24.1879 0
+      vertex 18.1045 22.9945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8955 22.9945 0
+      vertex 17.77 24.1879 0
+      vertex 18.23 24.1879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.691 22.9511 0
+      vertex 17.77 24.1879 0
+      vertex 17.8955 22.9945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3202 24.0923 0
+      vertex 17.691 22.9511 0
+      vertex 17.5 22.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.9 23.9053 0
+      vertex 17.5 22.866 0
+      vertex 17.3309 22.7431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.691 22.9511 0
+      vertex 17.3202 24.0923 0
+      vertex 17.77 24.1879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5279 23.6349 0
+      vertex 17.3309 22.7431 0
+      vertex 17.191 22.5878 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.2202 23.2931 0
+      vertex 17.191 22.5878 0
+      vertex 17.0865 22.4067 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9902 22.8948 0
+      vertex 17.0865 22.4067 0
+      vertex 17.0219 22.2079 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5 22.866 0
+      vertex 16.9 23.9053 0
+      vertex 17.3202 24.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8481 22.4574 0
+      vertex 17.0219 22.2079 0
+      vertex 17 22 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9902 21.1052 0
+      vertex 17.0865 21.5933 0
+      vertex 16.2202 20.7069 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.0865 21.5933 0
+      vertex 15.9902 21.1052 0
+      vertex 17.0219 21.7921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3309 22.7431 0
+      vertex 16.5279 23.6349 0
+      vertex 16.9 23.9053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8481 21.5426 0
+      vertex 17.0219 21.7921 0
+      vertex 15.9902 21.1052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.191 22.5878 0
+      vertex 16.2202 23.2931 0
+      vertex 16.5279 23.6349 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.0219 21.7921 0
+      vertex 15.8481 21.5426 0
+      vertex 17 22 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0865 22.4067 0
+      vertex 15.9902 22.8948 0
+      vertex 16.2202 23.2931 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8 22 0
+      vertex 17 22 0
+      vertex 15.8481 21.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0219 22.2079 0
+      vertex 15.8481 22.4574 0
+      vertex 15.9902 22.8948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17 22 0
+      vertex 15.8 22 0
+      vertex 15.8481 22.4574 0
+    endloop
+  endfacet
+  facet normal 0.207895 -0.978151 0
+    outer loop
+      vertex 18.23 19.8121 0
+      vertex 18.6798 19.9077 1
+      vertex 18.23 19.8121 1
+    endloop
+  endfacet
+  facet normal 0.207895 -0.978151 0
+    outer loop
+      vertex 18.6798 19.9077 1
+      vertex 18.23 19.8121 0
+      vertex 18.6798 19.9077 0
+    endloop
+  endfacet
+  facet normal 0.587861 -0.808962 0
+    outer loop
+      vertex 19.1 20.0947 0
+      vertex 19.4721 20.3651 1
+      vertex 19.1 20.0947 1
+    endloop
+  endfacet
+  facet normal 0.587861 -0.808962 0
+    outer loop
+      vertex 19.4721 20.3651 1
+      vertex 19.1 20.0947 0
+      vertex 19.4721 20.3651 0
+    endloop
+  endfacet
+  facet normal 0.743208 -0.669061 0
+    outer loop
+      vertex 19.4721 20.3651 1
+      vertex 19.7798 20.7069 0
+      vertex 19.7798 20.7069 1
+    endloop
+  endfacet
+  facet normal 0.743208 -0.669061 0
+    outer loop
+      vertex 19.7798 20.7069 0
+      vertex 19.4721 20.3651 1
+      vertex 19.4721 20.3651 0
+    endloop
+  endfacet
+  facet normal 0.951069 -0.308978 0
+    outer loop
+      vertex 20.0098 21.1052 1
+      vertex 20.1519 21.5426 0
+      vertex 20.1519 21.5426 1
+    endloop
+  endfacet
+  facet normal 0.951069 -0.308978 0
+    outer loop
+      vertex 20.1519 21.5426 0
+      vertex 20.0098 21.1052 1
+      vertex 20.0098 21.1052 0
+    endloop
+  endfacet
+  facet normal -0.587861 -0.808962 0
+    outer loop
+      vertex 16.5279 20.3651 0
+      vertex 16.9 20.0947 1
+      vertex 16.5279 20.3651 1
+    endloop
+  endfacet
+  facet normal -0.587861 -0.808962 -0
+    outer loop
+      vertex 16.9 20.0947 1
+      vertex 16.5279 20.3651 0
+      vertex 16.9 20.0947 0
+    endloop
+  endfacet
+  facet normal -0.865986 -0.500067 0
+    outer loop
+      vertex 16.2202 20.7069 0
+      vertex 15.9902 21.1052 1
+      vertex 15.9902 21.1052 0
+    endloop
+  endfacet
+  facet normal -0.865986 -0.500067 0
+    outer loop
+      vertex 15.9902 21.1052 1
+      vertex 16.2202 20.7069 0
+      vertex 16.2202 20.7069 1
+    endloop
+  endfacet
+  facet normal -0.743208 -0.669061 0
+    outer loop
+      vertex 16.5279 20.3651 0
+      vertex 16.2202 20.7069 1
+      vertex 16.2202 20.7069 0
+    endloop
+  endfacet
+  facet normal -0.743208 -0.669061 0
+    outer loop
+      vertex 16.2202 20.7069 1
+      vertex 16.5279 20.3651 0
+      vertex 16.5279 20.3651 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex 18.6798 19.9077 0
+      vertex 19.1 20.0947 1
+      vertex 18.6798 19.9077 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex 19.1 20.0947 1
+      vertex 18.6798 19.9077 0
+      vertex 19.1 20.0947 0
+    endloop
+  endfacet
+  facet normal -0.207895 -0.978151 0
+    outer loop
+      vertex 17.3202 19.9077 0
+      vertex 17.77 19.8121 1
+      vertex 17.3202 19.9077 1
+    endloop
+  endfacet
+  facet normal -0.207895 -0.978151 -0
+    outer loop
+      vertex 17.77 19.8121 1
+      vertex 17.3202 19.9077 0
+      vertex 17.77 19.8121 0
+    endloop
+  endfacet
+  facet normal -0.951069 -0.308978 0
+    outer loop
+      vertex 15.9902 21.1052 0
+      vertex 15.8481 21.5426 1
+      vertex 15.8481 21.5426 0
+    endloop
+  endfacet
+  facet normal -0.951069 -0.308978 0
+    outer loop
+      vertex 15.8481 21.5426 1
+      vertex 15.9902 21.1052 0
+      vertex 15.9902 21.1052 1
+    endloop
+  endfacet
+  facet normal -0.994516 -0.104583 0
+    outer loop
+      vertex 15.8481 21.5426 0
+      vertex 15.8 22 1
+      vertex 15.8 22 0
+    endloop
+  endfacet
+  facet normal -0.994516 -0.104583 0
+    outer loop
+      vertex 15.8 22 1
+      vertex 15.8481 21.5426 0
+      vertex 15.8481 21.5426 1
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 0
+    outer loop
+      vertex 16.9 20.0947 0
+      vertex 17.3202 19.9077 1
+      vertex 16.9 20.0947 1
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 -0
+    outer loop
+      vertex 17.3202 19.9077 1
+      vertex 16.9 20.0947 0
+      vertex 17.3202 19.9077 0
+    endloop
+  endfacet
+  facet normal -0.994498 -0.104759 0
+    outer loop
+      vertex 19 22 0
+      vertex 18.9781 22.2079 1
+      vertex 18.9781 22.2079 0
+    endloop
+  endfacet
+  facet normal -0.994498 -0.104759 0
+    outer loop
+      vertex 18.9781 22.2079 1
+      vertex 19 22 0
+      vertex 19 22 1
+    endloop
+  endfacet
+  facet normal 0.994498 -0.104759 0
+    outer loop
+      vertex 17 22 1
+      vertex 17.0219 22.2079 0
+      vertex 17.0219 22.2079 1
+    endloop
+  endfacet
+  facet normal 0.994498 -0.104759 0
+    outer loop
+      vertex 17.0219 22.2079 0
+      vertex 17 22 1
+      vertex 17 22 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 17.8955 22.9945 0
+      vertex 18.1045 22.9945 1
+      vertex 17.8955 22.9945 1
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.1045 22.9945 1
+      vertex 17.8955 22.9945 0
+      vertex 18.1045 22.9945 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.1045 21.0055 0
+      vertex 17.8955 21.0055 1
+      vertex 18.1045 21.0055 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.8955 21.0055 1
+      vertex 18.1045 21.0055 0
+      vertex 17.8955 21.0055 0
+    endloop
+  endfacet
+  facet normal -0.587916 -0.808922 0
+    outer loop
+      vertex 18.5 22.866 0
+      vertex 18.6691 22.7431 1
+      vertex 18.5 22.866 1
+    endloop
+  endfacet
+  facet normal -0.587916 -0.808922 -0
+    outer loop
+      vertex 18.6691 22.7431 1
+      vertex 18.5 22.866 0
+      vertex 18.6691 22.7431 0
+    endloop
+  endfacet
+  facet normal -0.406981 -0.913436 0
+    outer loop
+      vertex 18.309 22.9511 0
+      vertex 18.5 22.866 1
+      vertex 18.309 22.9511 1
+    endloop
+  endfacet
+  facet normal -0.406981 -0.913436 -0
+    outer loop
+      vertex 18.5 22.866 1
+      vertex 18.309 22.9511 0
+      vertex 18.5 22.866 0
+    endloop
+  endfacet
+  facet normal 0.587916 -0.808922 0
+    outer loop
+      vertex 17.3309 22.7431 0
+      vertex 17.5 22.866 1
+      vertex 17.3309 22.7431 1
+    endloop
+  endfacet
+  facet normal 0.587916 -0.808922 0
+    outer loop
+      vertex 17.5 22.866 1
+      vertex 17.3309 22.7431 0
+      vertex 17.5 22.866 0
+    endloop
+  endfacet
+  facet normal 0.207601 -0.978214 0
+    outer loop
+      vertex 17.691 22.9511 0
+      vertex 17.8955 22.9945 1
+      vertex 17.691 22.9511 1
+    endloop
+  endfacet
+  facet normal 0.207601 -0.978214 0
+    outer loop
+      vertex 17.8955 22.9945 1
+      vertex 17.691 22.9511 0
+      vertex 17.8955 22.9945 0
+    endloop
+  endfacet
+  facet normal -0.866146 -0.499791 0
+    outer loop
+      vertex 18.9135 22.4067 0
+      vertex 18.809 22.5878 1
+      vertex 18.809 22.5878 0
+    endloop
+  endfacet
+  facet normal -0.866146 -0.499791 0
+    outer loop
+      vertex 18.809 22.5878 1
+      vertex 18.9135 22.4067 0
+      vertex 18.9135 22.4067 1
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309043 0
+    outer loop
+      vertex 18.9781 22.2079 0
+      vertex 18.9135 22.4067 1
+      vertex 18.9135 22.4067 0
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309043 0
+    outer loop
+      vertex 18.9135 22.4067 1
+      vertex 18.9781 22.2079 0
+      vertex 18.9781 22.2079 1
+    endloop
+  endfacet
+  facet normal -0.742985 -0.669308 0
+    outer loop
+      vertex 18.809 22.5878 0
+      vertex 18.6691 22.7431 1
+      vertex 18.6691 22.7431 0
+    endloop
+  endfacet
+  facet normal -0.742985 -0.669308 0
+    outer loop
+      vertex 18.6691 22.7431 1
+      vertex 18.809 22.5878 0
+      vertex 18.809 22.5878 1
+    endloop
+  endfacet
+  facet normal -0.207601 -0.978214 0
+    outer loop
+      vertex 18.1045 22.9945 0
+      vertex 18.309 22.9511 1
+      vertex 18.1045 22.9945 1
+    endloop
+  endfacet
+  facet normal -0.207601 -0.978214 -0
+    outer loop
+      vertex 18.309 22.9511 1
+      vertex 18.1045 22.9945 0
+      vertex 18.309 22.9511 0
+    endloop
+  endfacet
+  facet normal 0.866146 -0.499791 0
+    outer loop
+      vertex 17.0865 22.4067 1
+      vertex 17.191 22.5878 0
+      vertex 17.191 22.5878 1
+    endloop
+  endfacet
+  facet normal 0.866146 -0.499791 0
+    outer loop
+      vertex 17.191 22.5878 0
+      vertex 17.0865 22.4067 1
+      vertex 17.0865 22.4067 0
+    endloop
+  endfacet
+  facet normal 0.742985 -0.669308 0
+    outer loop
+      vertex 17.191 22.5878 1
+      vertex 17.3309 22.7431 0
+      vertex 17.3309 22.7431 1
+    endloop
+  endfacet
+  facet normal 0.742985 -0.669308 0
+    outer loop
+      vertex 17.3309 22.7431 0
+      vertex 17.191 22.5878 1
+      vertex 17.191 22.5878 0
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309043 0
+    outer loop
+      vertex 17.0219 22.2079 1
+      vertex 17.0865 22.4067 0
+      vertex 17.0865 22.4067 1
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309043 0
+    outer loop
+      vertex 17.0865 22.4067 0
+      vertex 17.0219 22.2079 1
+      vertex 17.0219 22.2079 0
+    endloop
+  endfacet
+  facet normal 0.406981 -0.913436 0
+    outer loop
+      vertex 17.5 22.866 0
+      vertex 17.691 22.9511 1
+      vertex 17.5 22.866 1
+    endloop
+  endfacet
+  facet normal 0.406981 -0.913436 0
+    outer loop
+      vertex 17.691 22.9511 1
+      vertex 17.5 22.866 0
+      vertex 17.691 22.9511 0
+    endloop
+  endfacet
+  facet normal -0.994498 0.104759 0
+    outer loop
+      vertex 18.9781 21.7921 0
+      vertex 19 22 1
+      vertex 19 22 0
+    endloop
+  endfacet
+  facet normal -0.994498 0.104759 0
+    outer loop
+      vertex 19 22 1
+      vertex 18.9781 21.7921 0
+      vertex 18.9781 21.7921 1
+    endloop
+  endfacet
+  facet normal -0.207601 0.978214 0
+    outer loop
+      vertex 18.309 21.0489 0
+      vertex 18.1045 21.0055 1
+      vertex 18.309 21.0489 1
+    endloop
+  endfacet
+  facet normal -0.207601 0.978214 0
+    outer loop
+      vertex 18.1045 21.0055 1
+      vertex 18.309 21.0489 0
+      vertex 18.1045 21.0055 0
+    endloop
+  endfacet
+  facet normal -0.742985 0.669308 0
+    outer loop
+      vertex 18.6691 21.2569 0
+      vertex 18.809 21.4122 1
+      vertex 18.809 21.4122 0
+    endloop
+  endfacet
+  facet normal -0.742985 0.669308 0
+    outer loop
+      vertex 18.809 21.4122 1
+      vertex 18.6691 21.2569 0
+      vertex 18.6691 21.2569 1
+    endloop
+  endfacet
+  facet normal -0.951048 0.309043 0
+    outer loop
+      vertex 18.9135 21.5933 0
+      vertex 18.9781 21.7921 1
+      vertex 18.9781 21.7921 0
+    endloop
+  endfacet
+  facet normal -0.951048 0.309043 0
+    outer loop
+      vertex 18.9781 21.7921 1
+      vertex 18.9135 21.5933 0
+      vertex 18.9135 21.5933 1
+    endloop
+  endfacet
+  facet normal -0.866146 0.499791 0
+    outer loop
+      vertex 18.809 21.4122 0
+      vertex 18.9135 21.5933 1
+      vertex 18.9135 21.5933 0
+    endloop
+  endfacet
+  facet normal -0.866146 0.499791 0
+    outer loop
+      vertex 18.9135 21.5933 1
+      vertex 18.809 21.4122 0
+      vertex 18.809 21.4122 1
+    endloop
+  endfacet
+  facet normal 0.406981 0.913436 -0
+    outer loop
+      vertex 17.691 21.0489 0
+      vertex 17.5 21.134 1
+      vertex 17.691 21.0489 1
+    endloop
+  endfacet
+  facet normal 0.406981 0.913436 0
+    outer loop
+      vertex 17.5 21.134 1
+      vertex 17.691 21.0489 0
+      vertex 17.5 21.134 0
+    endloop
+  endfacet
+  facet normal 0.866146 0.499791 0
+    outer loop
+      vertex 17.191 21.4122 1
+      vertex 17.0865 21.5933 0
+      vertex 17.0865 21.5933 1
+    endloop
+  endfacet
+  facet normal 0.866146 0.499791 0
+    outer loop
+      vertex 17.0865 21.5933 0
+      vertex 17.191 21.4122 1
+      vertex 17.191 21.4122 0
+    endloop
+  endfacet
+  facet normal -0.587916 0.808922 0
+    outer loop
+      vertex 18.6691 21.2569 0
+      vertex 18.5 21.134 1
+      vertex 18.6691 21.2569 1
+    endloop
+  endfacet
+  facet normal -0.587916 0.808922 0
+    outer loop
+      vertex 18.5 21.134 1
+      vertex 18.6691 21.2569 0
+      vertex 18.5 21.134 0
+    endloop
+  endfacet
+  facet normal -0.406981 0.913436 0
+    outer loop
+      vertex 18.5 21.134 0
+      vertex 18.309 21.0489 1
+      vertex 18.5 21.134 1
+    endloop
+  endfacet
+  facet normal -0.406981 0.913436 0
+    outer loop
+      vertex 18.309 21.0489 1
+      vertex 18.5 21.134 0
+      vertex 18.309 21.0489 0
+    endloop
+  endfacet
+  facet normal 0.207601 0.978214 -0
+    outer loop
+      vertex 17.8955 21.0055 0
+      vertex 17.691 21.0489 1
+      vertex 17.8955 21.0055 1
+    endloop
+  endfacet
+  facet normal 0.207601 0.978214 0
+    outer loop
+      vertex 17.691 21.0489 1
+      vertex 17.8955 21.0055 0
+      vertex 17.691 21.0489 0
+    endloop
+  endfacet
+  facet normal 0.587916 0.808922 -0
+    outer loop
+      vertex 17.5 21.134 0
+      vertex 17.3309 21.2569 1
+      vertex 17.5 21.134 1
+    endloop
+  endfacet
+  facet normal 0.587916 0.808922 0
+    outer loop
+      vertex 17.3309 21.2569 1
+      vertex 17.5 21.134 0
+      vertex 17.3309 21.2569 0
+    endloop
+  endfacet
+  facet normal 0.742985 0.669308 0
+    outer loop
+      vertex 17.3309 21.2569 1
+      vertex 17.191 21.4122 0
+      vertex 17.191 21.4122 1
+    endloop
+  endfacet
+  facet normal 0.742985 0.669308 0
+    outer loop
+      vertex 17.191 21.4122 0
+      vertex 17.3309 21.2569 1
+      vertex 17.3309 21.2569 0
+    endloop
+  endfacet
+  facet normal 0.951048 0.309043 0
+    outer loop
+      vertex 17.0865 21.5933 1
+      vertex 17.0219 21.7921 0
+      vertex 17.0219 21.7921 1
+    endloop
+  endfacet
+  facet normal 0.951048 0.309043 0
+    outer loop
+      vertex 17.0219 21.7921 0
+      vertex 17.0865 21.5933 1
+      vertex 17.0865 21.5933 0
+    endloop
+  endfacet
+  facet normal 0.994498 0.104759 0
+    outer loop
+      vertex 17.0219 21.7921 1
+      vertex 17 22 0
+      vertex 17 22 1
+    endloop
+  endfacet
+  facet normal 0.994498 0.104759 0
+    outer loop
+      vertex 17 22 0
+      vertex 17.0219 21.7921 1
+      vertex 17.0219 21.7921 0
+    endloop
+  endfacet
+  facet normal 0.994516 0.104583 0
+    outer loop
+      vertex -15.8 38 1
+      vertex -15.8481 38.4574 0
+      vertex -15.8481 38.4574 1
+    endloop
+  endfacet
+  facet normal 0.994516 0.104583 0
+    outer loop
+      vertex -15.8481 38.4574 0
+      vertex -15.8 38 1
+      vertex -15.8 38 0
+    endloop
+  endfacet
+  facet normal -0.994516 0.104583 0
+    outer loop
+      vertex -20.2 38 0
+      vertex -20.1519 38.4574 1
+      vertex -20.1519 38.4574 0
+    endloop
+  endfacet
+  facet normal -0.994516 0.104583 0
+    outer loop
+      vertex -20.1519 38.4574 1
+      vertex -20.2 38 0
+      vertex -20.2 38 1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.77 40.1879 0
+      vertex -18.23 40.1879 1
+      vertex -17.77 40.1879 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.23 40.1879 1
+      vertex -17.77 40.1879 0
+      vertex -18.23 40.1879 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -18.23 35.8121 0
+      vertex -17.77 35.8121 1
+      vertex -18.23 35.8121 1
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -17.77 35.8121 1
+      vertex -18.23 35.8121 0
+      vertex -17.77 35.8121 0
+    endloop
+  endfacet
+  facet normal 0.743208 0.669061 0
+    outer loop
+      vertex -16.2202 39.2931 1
+      vertex -16.5279 39.6349 0
+      vertex -16.5279 39.6349 1
+    endloop
+  endfacet
+  facet normal 0.743208 0.669061 0
+    outer loop
+      vertex -16.5279 39.6349 0
+      vertex -16.2202 39.2931 1
+      vertex -16.2202 39.2931 0
+    endloop
+  endfacet
+  facet normal 0.951069 0.308978 0
+    outer loop
+      vertex -15.8481 38.4574 1
+      vertex -15.9902 38.8948 0
+      vertex -15.9902 38.8948 1
+    endloop
+  endfacet
+  facet normal 0.951069 0.308978 0
+    outer loop
+      vertex -15.9902 38.8948 0
+      vertex -15.8481 38.4574 1
+      vertex -15.8481 38.4574 0
+    endloop
+  endfacet
+  facet normal -0.587861 0.808962 0
+    outer loop
+      vertex -19.1 39.9053 0
+      vertex -19.4721 39.6349 1
+      vertex -19.1 39.9053 1
+    endloop
+  endfacet
+  facet normal -0.587861 0.808962 0
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -19.1 39.9053 0
+      vertex -19.4721 39.6349 0
+    endloop
+  endfacet
+  facet normal -0.207895 0.978151 0
+    outer loop
+      vertex -18.23 40.1879 0
+      vertex -18.6798 40.0923 1
+      vertex -18.23 40.1879 1
+    endloop
+  endfacet
+  facet normal -0.207895 0.978151 0
+    outer loop
+      vertex -18.6798 40.0923 1
+      vertex -18.23 40.1879 0
+      vertex -18.6798 40.0923 0
+    endloop
+  endfacet
+  facet normal 0.865986 -0.500067 0
+    outer loop
+      vertex -16.2202 36.7069 1
+      vertex -15.9902 37.1052 0
+      vertex -15.9902 37.1052 1
+    endloop
+  endfacet
+  facet normal 0.865986 -0.500067 0
+    outer loop
+      vertex -15.9902 37.1052 0
+      vertex -16.2202 36.7069 1
+      vertex -16.2202 36.7069 0
+    endloop
+  endfacet
+  facet normal 0.865986 0.500067 0
+    outer loop
+      vertex -15.9902 38.8948 1
+      vertex -16.2202 39.2931 0
+      vertex -16.2202 39.2931 1
+    endloop
+  endfacet
+  facet normal 0.865986 0.500067 0
+    outer loop
+      vertex -16.2202 39.2931 0
+      vertex -15.9902 38.8948 1
+      vertex -15.9902 38.8948 0
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 -0
+    outer loop
+      vertex -16.9 39.9053 0
+      vertex -17.3202 40.0923 1
+      vertex -16.9 39.9053 1
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 0
+    outer loop
+      vertex -17.3202 40.0923 1
+      vertex -16.9 39.9053 0
+      vertex -17.3202 40.0923 0
+    endloop
+  endfacet
+  facet normal 0.207895 0.978151 -0
+    outer loop
+      vertex -17.3202 40.0923 0
+      vertex -17.77 40.1879 1
+      vertex -17.3202 40.0923 1
+    endloop
+  endfacet
+  facet normal 0.207895 0.978151 0
+    outer loop
+      vertex -17.77 40.1879 1
+      vertex -17.3202 40.0923 0
+      vertex -17.77 40.1879 0
+    endloop
+  endfacet
+  facet normal 0.587861 0.808962 -0
+    outer loop
+      vertex -16.5279 39.6349 0
+      vertex -16.9 39.9053 1
+      vertex -16.5279 39.6349 1
+    endloop
+  endfacet
+  facet normal 0.587861 0.808962 0
+    outer loop
+      vertex -16.9 39.9053 1
+      vertex -16.5279 39.6349 0
+      vertex -16.9 39.9053 0
+    endloop
+  endfacet
+  facet normal -0.865986 0.500067 0
+    outer loop
+      vertex -20.0098 38.8948 0
+      vertex -19.7798 39.2931 1
+      vertex -19.7798 39.2931 0
+    endloop
+  endfacet
+  facet normal -0.865986 0.500067 0
+    outer loop
+      vertex -19.7798 39.2931 1
+      vertex -20.0098 38.8948 0
+      vertex -20.0098 38.8948 1
+    endloop
+  endfacet
+  facet normal -0.743208 0.669061 0
+    outer loop
+      vertex -19.7798 39.2931 0
+      vertex -19.4721 39.6349 1
+      vertex -19.4721 39.6349 0
+    endloop
+  endfacet
+  facet normal -0.743208 0.669061 0
+    outer loop
+      vertex -19.4721 39.6349 1
+      vertex -19.7798 39.2931 0
+      vertex -19.7798 39.2931 1
+    endloop
+  endfacet
+  facet normal -0.951069 0.308978 0
+    outer loop
+      vertex -20.1519 38.4574 0
+      vertex -20.0098 38.8948 1
+      vertex -20.0098 38.8948 0
+    endloop
+  endfacet
+  facet normal -0.951069 0.308978 0
+    outer loop
+      vertex -20.0098 38.8948 1
+      vertex -20.1519 38.4574 0
+      vertex -20.1519 38.4574 1
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex -18.6798 40.0923 0
+      vertex -19.1 39.9053 1
+      vertex -18.6798 40.0923 1
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex -19.1 39.9053 1
+      vertex -18.6798 40.0923 0
+      vertex -19.1 39.9053 0
+    endloop
+  endfacet
+  facet normal 0.994516 -0.104583 0
+    outer loop
+      vertex -15.8481 37.5426 1
+      vertex -15.8 38 0
+      vertex -15.8 38 1
+    endloop
+  endfacet
+  facet normal 0.994516 -0.104583 0
+    outer loop
+      vertex -15.8 38 0
+      vertex -15.8481 37.5426 1
+      vertex -15.8481 37.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17 38 0
+      vertex -15.8 38 0
+      vertex -15.8481 37.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0219 37.7921 0
+      vertex -15.8481 37.5426 0
+      vertex -15.9902 37.1052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8 38 0
+      vertex -17 38 0
+      vertex -15.8481 38.4574 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0865 37.5933 0
+      vertex -15.9902 37.1052 0
+      vertex -16.2202 36.7069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0219 38.2079 0
+      vertex -15.8481 38.4574 0
+      vertex -17 38 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.191 37.4122 0
+      vertex -16.2202 36.7069 0
+      vertex -16.5279 36.3651 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.8481 38.4574 0
+      vertex -17.0219 38.2079 0
+      vertex -15.9902 38.8948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3309 37.2569 0
+      vertex -16.5279 36.3651 0
+      vertex -16.9 36.0947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0865 38.4067 0
+      vertex -15.9902 38.8948 0
+      vertex -17.0219 38.2079 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.9902 38.8948 0
+      vertex -17.0865 38.4067 0
+      vertex -16.2202 39.2931 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8481 37.5426 0
+      vertex -17.0219 37.7921 0
+      vertex -17 38 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9902 37.1052 0
+      vertex -17.0865 37.5933 0
+      vertex -17.0219 37.7921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.2202 36.7069 0
+      vertex -17.191 37.4122 0
+      vertex -17.0865 37.5933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5 37.134 0
+      vertex -16.9 36.0947 0
+      vertex -17.3202 35.9077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5279 36.3651 0
+      vertex -17.3309 37.2569 0
+      vertex -17.191 37.4122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.9 36.0947 0
+      vertex -17.5 37.134 0
+      vertex -17.3309 37.2569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3202 35.9077 0
+      vertex -17.691 37.0489 0
+      vertex -17.5 37.134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.77 35.8121 0
+      vertex -17.691 37.0489 0
+      vertex -17.3202 35.9077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.77 35.8121 0
+      vertex -17.8955 37.0055 0
+      vertex -17.691 37.0489 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.77 35.8121 0
+      vertex -18.1045 37.0055 0
+      vertex -17.8955 37.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.23 35.8121 0
+      vertex -18.1045 37.0055 0
+      vertex -17.77 35.8121 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.23 35.8121 0
+      vertex -18.309 37.0489 0
+      vertex -18.1045 37.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6798 35.9077 0
+      vertex -18.309 37.0489 0
+      vertex -18.23 35.8121 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.309 37.0489 0
+      vertex -18.6798 35.9077 0
+      vertex -18.5 37.134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.1 36.0947 0
+      vertex -18.5 37.134 0
+      vertex -18.6798 35.9077 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.5 37.134 0
+      vertex -19.1 36.0947 0
+      vertex -18.6691 37.2569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 36.3651 0
+      vertex -18.6691 37.2569 0
+      vertex -19.1 36.0947 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.6691 37.2569 0
+      vertex -19.4721 36.3651 0
+      vertex -18.809 37.4122 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.809 37.4122 0
+      vertex -19.7798 36.7069 0
+      vertex -18.9135 37.5933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.7798 36.7069 0
+      vertex -18.809 37.4122 0
+      vertex -19.4721 36.3651 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.191 38.5878 0
+      vertex -16.2202 39.2931 0
+      vertex -17.0865 38.4067 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.2202 39.2931 0
+      vertex -17.191 38.5878 0
+      vertex -16.5279 39.6349 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3309 38.7431 0
+      vertex -16.5279 39.6349 0
+      vertex -17.191 38.5878 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.5279 39.6349 0
+      vertex -17.3309 38.7431 0
+      vertex -16.9 39.9053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5 38.866 0
+      vertex -16.9 39.9053 0
+      vertex -17.3309 38.7431 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.9 39.9053 0
+      vertex -17.5 38.866 0
+      vertex -17.3202 40.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.691 38.9511 0
+      vertex -17.3202 40.0923 0
+      vertex -17.5 38.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.691 38.9511 0
+      vertex -17.77 40.1879 0
+      vertex -17.3202 40.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8955 38.9945 0
+      vertex -17.77 40.1879 0
+      vertex -17.691 38.9511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.1045 38.9945 0
+      vertex -17.77 40.1879 0
+      vertex -17.8955 38.9945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.1045 38.9945 0
+      vertex -18.23 40.1879 0
+      vertex -17.77 40.1879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.309 38.9511 0
+      vertex -18.23 40.1879 0
+      vertex -18.1045 38.9945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6798 40.0923 0
+      vertex -18.309 38.9511 0
+      vertex -18.5 38.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.1 39.9053 0
+      vertex -18.5 38.866 0
+      vertex -18.6691 38.7431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.309 38.9511 0
+      vertex -18.6798 40.0923 0
+      vertex -18.23 40.1879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 39.6349 0
+      vertex -18.6691 38.7431 0
+      vertex -18.809 38.5878 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.7798 39.2931 0
+      vertex -18.809 38.5878 0
+      vertex -18.9135 38.4067 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0098 38.8948 0
+      vertex -18.9135 38.4067 0
+      vertex -18.9781 38.2079 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 38.866 0
+      vertex -19.1 39.9053 0
+      vertex -18.6798 40.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1519 38.4574 0
+      vertex -18.9781 38.2079 0
+      vertex -19 38 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0098 37.1052 0
+      vertex -18.9135 37.5933 0
+      vertex -19.7798 36.7069 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9135 37.5933 0
+      vertex -20.0098 37.1052 0
+      vertex -18.9781 37.7921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6691 38.7431 0
+      vertex -19.4721 39.6349 0
+      vertex -19.1 39.9053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1519 37.5426 0
+      vertex -18.9781 37.7921 0
+      vertex -20.0098 37.1052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.809 38.5878 0
+      vertex -19.7798 39.2931 0
+      vertex -19.4721 39.6349 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9781 37.7921 0
+      vertex -20.1519 37.5426 0
+      vertex -19 38 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9135 38.4067 0
+      vertex -20.0098 38.8948 0
+      vertex -19.7798 39.2931 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.2 38 0
+      vertex -19 38 0
+      vertex -20.1519 37.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9781 38.2079 0
+      vertex -20.1519 38.4574 0
+      vertex -20.0098 38.8948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19 38 0
+      vertex -20.2 38 0
+      vertex -20.1519 38.4574 0
+    endloop
+  endfacet
+  facet normal 0.207895 -0.978151 0
+    outer loop
+      vertex -17.77 35.8121 0
+      vertex -17.3202 35.9077 1
+      vertex -17.77 35.8121 1
+    endloop
+  endfacet
+  facet normal 0.207895 -0.978151 0
+    outer loop
+      vertex -17.3202 35.9077 1
+      vertex -17.77 35.8121 0
+      vertex -17.3202 35.9077 0
+    endloop
+  endfacet
+  facet normal 0.587861 -0.808962 0
+    outer loop
+      vertex -16.9 36.0947 0
+      vertex -16.5279 36.3651 1
+      vertex -16.9 36.0947 1
+    endloop
+  endfacet
+  facet normal 0.587861 -0.808962 0
+    outer loop
+      vertex -16.5279 36.3651 1
+      vertex -16.9 36.0947 0
+      vertex -16.5279 36.3651 0
+    endloop
+  endfacet
+  facet normal 0.743208 -0.669061 0
+    outer loop
+      vertex -16.5279 36.3651 1
+      vertex -16.2202 36.7069 0
+      vertex -16.2202 36.7069 1
+    endloop
+  endfacet
+  facet normal 0.743208 -0.669061 0
+    outer loop
+      vertex -16.2202 36.7069 0
+      vertex -16.5279 36.3651 1
+      vertex -16.5279 36.3651 0
+    endloop
+  endfacet
+  facet normal 0.951069 -0.308978 0
+    outer loop
+      vertex -15.9902 37.1052 1
+      vertex -15.8481 37.5426 0
+      vertex -15.8481 37.5426 1
+    endloop
+  endfacet
+  facet normal 0.951069 -0.308978 0
+    outer loop
+      vertex -15.8481 37.5426 0
+      vertex -15.9902 37.1052 1
+      vertex -15.9902 37.1052 0
+    endloop
+  endfacet
+  facet normal -0.587861 -0.808962 0
+    outer loop
+      vertex -19.4721 36.3651 0
+      vertex -19.1 36.0947 1
+      vertex -19.4721 36.3651 1
+    endloop
+  endfacet
+  facet normal -0.587861 -0.808962 -0
+    outer loop
+      vertex -19.1 36.0947 1
+      vertex -19.4721 36.3651 0
+      vertex -19.1 36.0947 0
+    endloop
+  endfacet
+  facet normal -0.865986 -0.500067 0
+    outer loop
+      vertex -19.7798 36.7069 0
+      vertex -20.0098 37.1052 1
+      vertex -20.0098 37.1052 0
+    endloop
+  endfacet
+  facet normal -0.865986 -0.500067 0
+    outer loop
+      vertex -20.0098 37.1052 1
+      vertex -19.7798 36.7069 0
+      vertex -19.7798 36.7069 1
+    endloop
+  endfacet
+  facet normal -0.743208 -0.669061 0
+    outer loop
+      vertex -19.4721 36.3651 0
+      vertex -19.7798 36.7069 1
+      vertex -19.7798 36.7069 0
+    endloop
+  endfacet
+  facet normal -0.743208 -0.669061 0
+    outer loop
+      vertex -19.7798 36.7069 1
+      vertex -19.4721 36.3651 0
+      vertex -19.4721 36.3651 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex -17.3202 35.9077 0
+      vertex -16.9 36.0947 1
+      vertex -17.3202 35.9077 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex -16.9 36.0947 1
+      vertex -17.3202 35.9077 0
+      vertex -16.9 36.0947 0
+    endloop
+  endfacet
+  facet normal -0.207895 -0.978151 0
+    outer loop
+      vertex -18.6798 35.9077 0
+      vertex -18.23 35.8121 1
+      vertex -18.6798 35.9077 1
+    endloop
+  endfacet
+  facet normal -0.207895 -0.978151 -0
+    outer loop
+      vertex -18.23 35.8121 1
+      vertex -18.6798 35.9077 0
+      vertex -18.23 35.8121 0
+    endloop
+  endfacet
+  facet normal -0.951069 -0.308978 0
+    outer loop
+      vertex -20.0098 37.1052 0
+      vertex -20.1519 37.5426 1
+      vertex -20.1519 37.5426 0
+    endloop
+  endfacet
+  facet normal -0.951069 -0.308978 0
+    outer loop
+      vertex -20.1519 37.5426 1
+      vertex -20.0098 37.1052 0
+      vertex -20.0098 37.1052 1
+    endloop
+  endfacet
+  facet normal -0.994516 -0.104583 0
+    outer loop
+      vertex -20.1519 37.5426 0
+      vertex -20.2 38 1
+      vertex -20.2 38 0
+    endloop
+  endfacet
+  facet normal -0.994516 -0.104583 0
+    outer loop
+      vertex -20.2 38 1
+      vertex -20.1519 37.5426 0
+      vertex -20.1519 37.5426 1
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 0
+    outer loop
+      vertex -19.1 36.0947 0
+      vertex -18.6798 35.9077 1
+      vertex -19.1 36.0947 1
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 -0
+    outer loop
+      vertex -18.6798 35.9077 1
+      vertex -19.1 36.0947 0
+      vertex -18.6798 35.9077 0
+    endloop
+  endfacet
+  facet normal -0.994498 -0.104759 0
+    outer loop
+      vertex -17 38 0
+      vertex -17.0219 38.2079 1
+      vertex -17.0219 38.2079 0
+    endloop
+  endfacet
+  facet normal -0.994498 -0.104759 0
+    outer loop
+      vertex -17.0219 38.2079 1
+      vertex -17 38 0
+      vertex -17 38 1
+    endloop
+  endfacet
+  facet normal 0.994498 -0.104759 0
+    outer loop
+      vertex -19 38 1
+      vertex -18.9781 38.2079 0
+      vertex -18.9781 38.2079 1
+    endloop
+  endfacet
+  facet normal 0.994498 -0.104759 0
+    outer loop
+      vertex -18.9781 38.2079 0
+      vertex -19 38 1
+      vertex -19 38 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -18.1045 38.9945 0
+      vertex -17.8955 38.9945 1
+      vertex -18.1045 38.9945 1
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -17.8955 38.9945 1
+      vertex -18.1045 38.9945 0
+      vertex -17.8955 38.9945 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.8955 37.0055 0
+      vertex -18.1045 37.0055 1
+      vertex -17.8955 37.0055 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.1045 37.0055 1
+      vertex -17.8955 37.0055 0
+      vertex -18.1045 37.0055 0
+    endloop
+  endfacet
+  facet normal -0.587916 -0.808922 0
+    outer loop
+      vertex -17.5 38.866 0
+      vertex -17.3309 38.7431 1
+      vertex -17.5 38.866 1
+    endloop
+  endfacet
+  facet normal -0.587916 -0.808922 -0
+    outer loop
+      vertex -17.3309 38.7431 1
+      vertex -17.5 38.866 0
+      vertex -17.3309 38.7431 0
+    endloop
+  endfacet
+  facet normal -0.406981 -0.913436 0
+    outer loop
+      vertex -17.691 38.9511 0
+      vertex -17.5 38.866 1
+      vertex -17.691 38.9511 1
+    endloop
+  endfacet
+  facet normal -0.406981 -0.913436 -0
+    outer loop
+      vertex -17.5 38.866 1
+      vertex -17.691 38.9511 0
+      vertex -17.5 38.866 0
+    endloop
+  endfacet
+  facet normal 0.587916 -0.808922 0
+    outer loop
+      vertex -18.6691 38.7431 0
+      vertex -18.5 38.866 1
+      vertex -18.6691 38.7431 1
+    endloop
+  endfacet
+  facet normal 0.587916 -0.808922 0
+    outer loop
+      vertex -18.5 38.866 1
+      vertex -18.6691 38.7431 0
+      vertex -18.5 38.866 0
+    endloop
+  endfacet
+  facet normal 0.207601 -0.978214 0
+    outer loop
+      vertex -18.309 38.9511 0
+      vertex -18.1045 38.9945 1
+      vertex -18.309 38.9511 1
+    endloop
+  endfacet
+  facet normal 0.207601 -0.978214 0
+    outer loop
+      vertex -18.1045 38.9945 1
+      vertex -18.309 38.9511 0
+      vertex -18.1045 38.9945 0
+    endloop
+  endfacet
+  facet normal -0.866146 -0.499791 0
+    outer loop
+      vertex -17.0865 38.4067 0
+      vertex -17.191 38.5878 1
+      vertex -17.191 38.5878 0
+    endloop
+  endfacet
+  facet normal -0.866146 -0.499791 0
+    outer loop
+      vertex -17.191 38.5878 1
+      vertex -17.0865 38.4067 0
+      vertex -17.0865 38.4067 1
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309043 0
+    outer loop
+      vertex -17.0219 38.2079 0
+      vertex -17.0865 38.4067 1
+      vertex -17.0865 38.4067 0
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309043 0
+    outer loop
+      vertex -17.0865 38.4067 1
+      vertex -17.0219 38.2079 0
+      vertex -17.0219 38.2079 1
+    endloop
+  endfacet
+  facet normal -0.742985 -0.669308 0
+    outer loop
+      vertex -17.191 38.5878 0
+      vertex -17.3309 38.7431 1
+      vertex -17.3309 38.7431 0
+    endloop
+  endfacet
+  facet normal -0.742985 -0.669308 0
+    outer loop
+      vertex -17.3309 38.7431 1
+      vertex -17.191 38.5878 0
+      vertex -17.191 38.5878 1
+    endloop
+  endfacet
+  facet normal -0.207601 -0.978214 0
+    outer loop
+      vertex -17.8955 38.9945 0
+      vertex -17.691 38.9511 1
+      vertex -17.8955 38.9945 1
+    endloop
+  endfacet
+  facet normal -0.207601 -0.978214 -0
+    outer loop
+      vertex -17.691 38.9511 1
+      vertex -17.8955 38.9945 0
+      vertex -17.691 38.9511 0
+    endloop
+  endfacet
+  facet normal 0.866146 -0.499791 0
+    outer loop
+      vertex -18.9135 38.4067 1
+      vertex -18.809 38.5878 0
+      vertex -18.809 38.5878 1
+    endloop
+  endfacet
+  facet normal 0.866146 -0.499791 0
+    outer loop
+      vertex -18.809 38.5878 0
+      vertex -18.9135 38.4067 1
+      vertex -18.9135 38.4067 0
+    endloop
+  endfacet
+  facet normal 0.742985 -0.669308 0
+    outer loop
+      vertex -18.809 38.5878 1
+      vertex -18.6691 38.7431 0
+      vertex -18.6691 38.7431 1
+    endloop
+  endfacet
+  facet normal 0.742985 -0.669308 0
+    outer loop
+      vertex -18.6691 38.7431 0
+      vertex -18.809 38.5878 1
+      vertex -18.809 38.5878 0
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309043 0
+    outer loop
+      vertex -18.9781 38.2079 1
+      vertex -18.9135 38.4067 0
+      vertex -18.9135 38.4067 1
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309043 0
+    outer loop
+      vertex -18.9135 38.4067 0
+      vertex -18.9781 38.2079 1
+      vertex -18.9781 38.2079 0
+    endloop
+  endfacet
+  facet normal 0.406981 -0.913436 0
+    outer loop
+      vertex -18.5 38.866 0
+      vertex -18.309 38.9511 1
+      vertex -18.5 38.866 1
+    endloop
+  endfacet
+  facet normal 0.406981 -0.913436 0
+    outer loop
+      vertex -18.309 38.9511 1
+      vertex -18.5 38.866 0
+      vertex -18.309 38.9511 0
+    endloop
+  endfacet
+  facet normal -0.994498 0.104759 0
+    outer loop
+      vertex -17.0219 37.7921 0
+      vertex -17 38 1
+      vertex -17 38 0
+    endloop
+  endfacet
+  facet normal -0.994498 0.104759 0
+    outer loop
+      vertex -17 38 1
+      vertex -17.0219 37.7921 0
+      vertex -17.0219 37.7921 1
+    endloop
+  endfacet
+  facet normal -0.207601 0.978214 0
+    outer loop
+      vertex -17.691 37.0489 0
+      vertex -17.8955 37.0055 1
+      vertex -17.691 37.0489 1
+    endloop
+  endfacet
+  facet normal -0.207601 0.978214 0
+    outer loop
+      vertex -17.8955 37.0055 1
+      vertex -17.691 37.0489 0
+      vertex -17.8955 37.0055 0
+    endloop
+  endfacet
+  facet normal -0.742985 0.669308 0
+    outer loop
+      vertex -17.3309 37.2569 0
+      vertex -17.191 37.4122 1
+      vertex -17.191 37.4122 0
+    endloop
+  endfacet
+  facet normal -0.742985 0.669308 0
+    outer loop
+      vertex -17.191 37.4122 1
+      vertex -17.3309 37.2569 0
+      vertex -17.3309 37.2569 1
+    endloop
+  endfacet
+  facet normal -0.951048 0.309043 0
+    outer loop
+      vertex -17.0865 37.5933 0
+      vertex -17.0219 37.7921 1
+      vertex -17.0219 37.7921 0
+    endloop
+  endfacet
+  facet normal -0.951048 0.309043 0
+    outer loop
+      vertex -17.0219 37.7921 1
+      vertex -17.0865 37.5933 0
+      vertex -17.0865 37.5933 1
+    endloop
+  endfacet
+  facet normal -0.866146 0.499791 0
+    outer loop
+      vertex -17.191 37.4122 0
+      vertex -17.0865 37.5933 1
+      vertex -17.0865 37.5933 0
+    endloop
+  endfacet
+  facet normal -0.866146 0.499791 0
+    outer loop
+      vertex -17.0865 37.5933 1
+      vertex -17.191 37.4122 0
+      vertex -17.191 37.4122 1
+    endloop
+  endfacet
+  facet normal 0.406981 0.913436 -0
+    outer loop
+      vertex -18.309 37.0489 0
+      vertex -18.5 37.134 1
+      vertex -18.309 37.0489 1
+    endloop
+  endfacet
+  facet normal 0.406981 0.913436 0
+    outer loop
+      vertex -18.5 37.134 1
+      vertex -18.309 37.0489 0
+      vertex -18.5 37.134 0
+    endloop
+  endfacet
+  facet normal 0.866146 0.499791 0
+    outer loop
+      vertex -18.809 37.4122 1
+      vertex -18.9135 37.5933 0
+      vertex -18.9135 37.5933 1
+    endloop
+  endfacet
+  facet normal 0.866146 0.499791 0
+    outer loop
+      vertex -18.9135 37.5933 0
+      vertex -18.809 37.4122 1
+      vertex -18.809 37.4122 0
+    endloop
+  endfacet
+  facet normal -0.587916 0.808922 0
+    outer loop
+      vertex -17.3309 37.2569 0
+      vertex -17.5 37.134 1
+      vertex -17.3309 37.2569 1
+    endloop
+  endfacet
+  facet normal -0.587916 0.808922 0
+    outer loop
+      vertex -17.5 37.134 1
+      vertex -17.3309 37.2569 0
+      vertex -17.5 37.134 0
+    endloop
+  endfacet
+  facet normal -0.406981 0.913436 0
+    outer loop
+      vertex -17.5 37.134 0
+      vertex -17.691 37.0489 1
+      vertex -17.5 37.134 1
+    endloop
+  endfacet
+  facet normal -0.406981 0.913436 0
+    outer loop
+      vertex -17.691 37.0489 1
+      vertex -17.5 37.134 0
+      vertex -17.691 37.0489 0
+    endloop
+  endfacet
+  facet normal 0.207601 0.978214 -0
+    outer loop
+      vertex -18.1045 37.0055 0
+      vertex -18.309 37.0489 1
+      vertex -18.1045 37.0055 1
+    endloop
+  endfacet
+  facet normal 0.207601 0.978214 0
+    outer loop
+      vertex -18.309 37.0489 1
+      vertex -18.1045 37.0055 0
+      vertex -18.309 37.0489 0
+    endloop
+  endfacet
+  facet normal 0.587916 0.808922 -0
+    outer loop
+      vertex -18.5 37.134 0
+      vertex -18.6691 37.2569 1
+      vertex -18.5 37.134 1
+    endloop
+  endfacet
+  facet normal 0.587916 0.808922 0
+    outer loop
+      vertex -18.6691 37.2569 1
+      vertex -18.5 37.134 0
+      vertex -18.6691 37.2569 0
+    endloop
+  endfacet
+  facet normal 0.742985 0.669308 0
+    outer loop
+      vertex -18.6691 37.2569 1
+      vertex -18.809 37.4122 0
+      vertex -18.809 37.4122 1
+    endloop
+  endfacet
+  facet normal 0.742985 0.669308 0
+    outer loop
+      vertex -18.809 37.4122 0
+      vertex -18.6691 37.2569 1
+      vertex -18.6691 37.2569 0
+    endloop
+  endfacet
+  facet normal 0.951048 0.309043 0
+    outer loop
+      vertex -18.9135 37.5933 1
+      vertex -18.9781 37.7921 0
+      vertex -18.9781 37.7921 1
+    endloop
+  endfacet
+  facet normal 0.951048 0.309043 0
+    outer loop
+      vertex -18.9781 37.7921 0
+      vertex -18.9135 37.5933 1
+      vertex -18.9135 37.5933 0
+    endloop
+  endfacet
+  facet normal 0.994498 0.104759 0
+    outer loop
+      vertex -18.9781 37.7921 1
+      vertex -19 38 0
+      vertex -19 38 1
+    endloop
+  endfacet
+  facet normal 0.994498 0.104759 0
+    outer loop
+      vertex -19 38 0
+      vertex -18.9781 37.7921 1
+      vertex -18.9781 37.7921 0
+    endloop
+  endfacet
+  facet normal 0.994516 0.104583 0
+    outer loop
+      vertex -15.8 22 1
+      vertex -15.8481 22.4574 0
+      vertex -15.8481 22.4574 1
+    endloop
+  endfacet
+  facet normal 0.994516 0.104583 0
+    outer loop
+      vertex -15.8481 22.4574 0
+      vertex -15.8 22 1
+      vertex -15.8 22 0
+    endloop
+  endfacet
+  facet normal -0.994516 0.104583 0
+    outer loop
+      vertex -20.2 22 0
+      vertex -20.1519 22.4574 1
+      vertex -20.1519 22.4574 0
+    endloop
+  endfacet
+  facet normal -0.994516 0.104583 0
+    outer loop
+      vertex -20.1519 22.4574 1
+      vertex -20.2 22 0
+      vertex -20.2 22 1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.77 24.1879 0
+      vertex -18.23 24.1879 1
+      vertex -17.77 24.1879 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.23 24.1879 1
+      vertex -17.77 24.1879 0
+      vertex -18.23 24.1879 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -18.23 19.8121 0
+      vertex -17.77 19.8121 1
+      vertex -18.23 19.8121 1
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -17.77 19.8121 1
+      vertex -18.23 19.8121 0
+      vertex -17.77 19.8121 0
+    endloop
+  endfacet
+  facet normal 0.743208 0.669061 0
+    outer loop
+      vertex -16.2202 23.2931 1
+      vertex -16.5279 23.6349 0
+      vertex -16.5279 23.6349 1
+    endloop
+  endfacet
+  facet normal 0.743208 0.669061 0
+    outer loop
+      vertex -16.5279 23.6349 0
+      vertex -16.2202 23.2931 1
+      vertex -16.2202 23.2931 0
+    endloop
+  endfacet
+  facet normal 0.951069 0.308978 0
+    outer loop
+      vertex -15.8481 22.4574 1
+      vertex -15.9902 22.8948 0
+      vertex -15.9902 22.8948 1
+    endloop
+  endfacet
+  facet normal 0.951069 0.308978 0
+    outer loop
+      vertex -15.9902 22.8948 0
+      vertex -15.8481 22.4574 1
+      vertex -15.8481 22.4574 0
+    endloop
+  endfacet
+  facet normal -0.587861 0.808962 0
+    outer loop
+      vertex -19.1 23.9053 0
+      vertex -19.4721 23.6349 1
+      vertex -19.1 23.9053 1
+    endloop
+  endfacet
+  facet normal -0.587861 0.808962 0
+    outer loop
+      vertex -19.4721 23.6349 1
+      vertex -19.1 23.9053 0
+      vertex -19.4721 23.6349 0
+    endloop
+  endfacet
+  facet normal -0.207895 0.978151 0
+    outer loop
+      vertex -18.23 24.1879 0
+      vertex -18.6798 24.0923 1
+      vertex -18.23 24.1879 1
+    endloop
+  endfacet
+  facet normal -0.207895 0.978151 0
+    outer loop
+      vertex -18.6798 24.0923 1
+      vertex -18.23 24.1879 0
+      vertex -18.6798 24.0923 0
+    endloop
+  endfacet
+  facet normal 0.865986 -0.500067 0
+    outer loop
+      vertex -16.2202 20.7069 1
+      vertex -15.9902 21.1052 0
+      vertex -15.9902 21.1052 1
+    endloop
+  endfacet
+  facet normal 0.865986 -0.500067 0
+    outer loop
+      vertex -15.9902 21.1052 0
+      vertex -16.2202 20.7069 1
+      vertex -16.2202 20.7069 0
+    endloop
+  endfacet
+  facet normal 0.865986 0.500067 0
+    outer loop
+      vertex -15.9902 22.8948 1
+      vertex -16.2202 23.2931 0
+      vertex -16.2202 23.2931 1
+    endloop
+  endfacet
+  facet normal 0.865986 0.500067 0
+    outer loop
+      vertex -16.2202 23.2931 0
+      vertex -15.9902 22.8948 1
+      vertex -15.9902 22.8948 0
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 -0
+    outer loop
+      vertex -16.9 23.9053 0
+      vertex -17.3202 24.0923 1
+      vertex -16.9 23.9053 1
+    endloop
+  endfacet
+  facet normal 0.406582 0.913614 0
+    outer loop
+      vertex -17.3202 24.0923 1
+      vertex -16.9 23.9053 0
+      vertex -17.3202 24.0923 0
+    endloop
+  endfacet
+  facet normal 0.207895 0.978151 -0
+    outer loop
+      vertex -17.3202 24.0923 0
+      vertex -17.77 24.1879 1
+      vertex -17.3202 24.0923 1
+    endloop
+  endfacet
+  facet normal 0.207895 0.978151 0
+    outer loop
+      vertex -17.77 24.1879 1
+      vertex -17.3202 24.0923 0
+      vertex -17.77 24.1879 0
+    endloop
+  endfacet
+  facet normal 0.587861 0.808962 -0
+    outer loop
+      vertex -16.5279 23.6349 0
+      vertex -16.9 23.9053 1
+      vertex -16.5279 23.6349 1
+    endloop
+  endfacet
+  facet normal 0.587861 0.808962 0
+    outer loop
+      vertex -16.9 23.9053 1
+      vertex -16.5279 23.6349 0
+      vertex -16.9 23.9053 0
+    endloop
+  endfacet
+  facet normal -0.865986 0.500067 0
+    outer loop
+      vertex -20.0098 22.8948 0
+      vertex -19.7798 23.2931 1
+      vertex -19.7798 23.2931 0
+    endloop
+  endfacet
+  facet normal -0.865986 0.500067 0
+    outer loop
+      vertex -19.7798 23.2931 1
+      vertex -20.0098 22.8948 0
+      vertex -20.0098 22.8948 1
+    endloop
+  endfacet
+  facet normal -0.743208 0.669061 0
+    outer loop
+      vertex -19.7798 23.2931 0
+      vertex -19.4721 23.6349 1
+      vertex -19.4721 23.6349 0
+    endloop
+  endfacet
+  facet normal -0.743208 0.669061 0
+    outer loop
+      vertex -19.4721 23.6349 1
+      vertex -19.7798 23.2931 0
+      vertex -19.7798 23.2931 1
+    endloop
+  endfacet
+  facet normal -0.951069 0.308978 0
+    outer loop
+      vertex -20.1519 22.4574 0
+      vertex -20.0098 22.8948 1
+      vertex -20.0098 22.8948 0
+    endloop
+  endfacet
+  facet normal -0.951069 0.308978 0
+    outer loop
+      vertex -20.0098 22.8948 1
+      vertex -20.1519 22.4574 0
+      vertex -20.1519 22.4574 1
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex -18.6798 24.0923 0
+      vertex -19.1 23.9053 1
+      vertex -18.6798 24.0923 1
+    endloop
+  endfacet
+  facet normal -0.406582 0.913614 0
+    outer loop
+      vertex -19.1 23.9053 1
+      vertex -18.6798 24.0923 0
+      vertex -19.1 23.9053 0
+    endloop
+  endfacet
+  facet normal 0.994516 -0.104583 0
+    outer loop
+      vertex -15.8481 21.5426 1
+      vertex -15.8 22 0
+      vertex -15.8 22 1
+    endloop
+  endfacet
+  facet normal 0.994516 -0.104583 0
+    outer loop
+      vertex -15.8 22 0
+      vertex -15.8481 21.5426 1
+      vertex -15.8481 21.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17 22 0
+      vertex -15.8 22 0
+      vertex -15.8481 21.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0219 21.7921 0
+      vertex -15.8481 21.5426 0
+      vertex -15.9902 21.1052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8 22 0
+      vertex -17 22 0
+      vertex -15.8481 22.4574 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0865 21.5933 0
+      vertex -15.9902 21.1052 0
+      vertex -16.2202 20.7069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0219 22.2079 0
+      vertex -15.8481 22.4574 0
+      vertex -17 22 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.191 21.4122 0
+      vertex -16.2202 20.7069 0
+      vertex -16.5279 20.3651 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.8481 22.4574 0
+      vertex -17.0219 22.2079 0
+      vertex -15.9902 22.8948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3309 21.2569 0
+      vertex -16.5279 20.3651 0
+      vertex -16.9 20.0947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0865 22.4067 0
+      vertex -15.9902 22.8948 0
+      vertex -17.0219 22.2079 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.9902 22.8948 0
+      vertex -17.0865 22.4067 0
+      vertex -16.2202 23.2931 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8481 21.5426 0
+      vertex -17.0219 21.7921 0
+      vertex -17 22 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9902 21.1052 0
+      vertex -17.0865 21.5933 0
+      vertex -17.0219 21.7921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.2202 20.7069 0
+      vertex -17.191 21.4122 0
+      vertex -17.0865 21.5933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5 21.134 0
+      vertex -16.9 20.0947 0
+      vertex -17.3202 19.9077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5279 20.3651 0
+      vertex -17.3309 21.2569 0
+      vertex -17.191 21.4122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.9 20.0947 0
+      vertex -17.5 21.134 0
+      vertex -17.3309 21.2569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3202 19.9077 0
+      vertex -17.691 21.0489 0
+      vertex -17.5 21.134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.77 19.8121 0
+      vertex -17.691 21.0489 0
+      vertex -17.3202 19.9077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.77 19.8121 0
+      vertex -17.8955 21.0055 0
+      vertex -17.691 21.0489 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.77 19.8121 0
+      vertex -18.1045 21.0055 0
+      vertex -17.8955 21.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.23 19.8121 0
+      vertex -18.1045 21.0055 0
+      vertex -17.77 19.8121 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.23 19.8121 0
+      vertex -18.309 21.0489 0
+      vertex -18.1045 21.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6798 19.9077 0
+      vertex -18.309 21.0489 0
+      vertex -18.23 19.8121 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.309 21.0489 0
+      vertex -18.6798 19.9077 0
+      vertex -18.5 21.134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.1 20.0947 0
+      vertex -18.5 21.134 0
+      vertex -18.6798 19.9077 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.5 21.134 0
+      vertex -19.1 20.0947 0
+      vertex -18.6691 21.2569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 20.3651 0
+      vertex -18.6691 21.2569 0
+      vertex -19.1 20.0947 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.6691 21.2569 0
+      vertex -19.4721 20.3651 0
+      vertex -18.809 21.4122 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.809 21.4122 0
+      vertex -19.7798 20.7069 0
+      vertex -18.9135 21.5933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.7798 20.7069 0
+      vertex -18.809 21.4122 0
+      vertex -19.4721 20.3651 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.191 22.5878 0
+      vertex -16.2202 23.2931 0
+      vertex -17.0865 22.4067 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.2202 23.2931 0
+      vertex -17.191 22.5878 0
+      vertex -16.5279 23.6349 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3309 22.7431 0
+      vertex -16.5279 23.6349 0
+      vertex -17.191 22.5878 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.5279 23.6349 0
+      vertex -17.3309 22.7431 0
+      vertex -16.9 23.9053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5 22.866 0
+      vertex -16.9 23.9053 0
+      vertex -17.3309 22.7431 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.9 23.9053 0
+      vertex -17.5 22.866 0
+      vertex -17.3202 24.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.691 22.9511 0
+      vertex -17.3202 24.0923 0
+      vertex -17.5 22.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.691 22.9511 0
+      vertex -17.77 24.1879 0
+      vertex -17.3202 24.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8955 22.9945 0
+      vertex -17.77 24.1879 0
+      vertex -17.691 22.9511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.1045 22.9945 0
+      vertex -17.77 24.1879 0
+      vertex -17.8955 22.9945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.1045 22.9945 0
+      vertex -18.23 24.1879 0
+      vertex -17.77 24.1879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.309 22.9511 0
+      vertex -18.23 24.1879 0
+      vertex -18.1045 22.9945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6798 24.0923 0
+      vertex -18.309 22.9511 0
+      vertex -18.5 22.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.1 23.9053 0
+      vertex -18.5 22.866 0
+      vertex -18.6691 22.7431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.309 22.9511 0
+      vertex -18.6798 24.0923 0
+      vertex -18.23 24.1879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.4721 23.6349 0
+      vertex -18.6691 22.7431 0
+      vertex -18.809 22.5878 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.7798 23.2931 0
+      vertex -18.809 22.5878 0
+      vertex -18.9135 22.4067 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0098 22.8948 0
+      vertex -18.9135 22.4067 0
+      vertex -18.9781 22.2079 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 22.866 0
+      vertex -19.1 23.9053 0
+      vertex -18.6798 24.0923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1519 22.4574 0
+      vertex -18.9781 22.2079 0
+      vertex -19 22 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0098 21.1052 0
+      vertex -18.9135 21.5933 0
+      vertex -19.7798 20.7069 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9135 21.5933 0
+      vertex -20.0098 21.1052 0
+      vertex -18.9781 21.7921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6691 22.7431 0
+      vertex -19.4721 23.6349 0
+      vertex -19.1 23.9053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1519 21.5426 0
+      vertex -18.9781 21.7921 0
+      vertex -20.0098 21.1052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.809 22.5878 0
+      vertex -19.7798 23.2931 0
+      vertex -19.4721 23.6349 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9781 21.7921 0
+      vertex -20.1519 21.5426 0
+      vertex -19 22 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9135 22.4067 0
+      vertex -20.0098 22.8948 0
+      vertex -19.7798 23.2931 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.2 22 0
+      vertex -19 22 0
+      vertex -20.1519 21.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9781 22.2079 0
+      vertex -20.1519 22.4574 0
+      vertex -20.0098 22.8948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19 22 0
+      vertex -20.2 22 0
+      vertex -20.1519 22.4574 0
+    endloop
+  endfacet
+  facet normal 0.207895 -0.978151 0
+    outer loop
+      vertex -17.77 19.8121 0
+      vertex -17.3202 19.9077 1
+      vertex -17.77 19.8121 1
+    endloop
+  endfacet
+  facet normal 0.207895 -0.978151 0
+    outer loop
+      vertex -17.3202 19.9077 1
+      vertex -17.77 19.8121 0
+      vertex -17.3202 19.9077 0
+    endloop
+  endfacet
+  facet normal 0.587861 -0.808962 0
+    outer loop
+      vertex -16.9 20.0947 0
+      vertex -16.5279 20.3651 1
+      vertex -16.9 20.0947 1
+    endloop
+  endfacet
+  facet normal 0.587861 -0.808962 0
+    outer loop
+      vertex -16.5279 20.3651 1
+      vertex -16.9 20.0947 0
+      vertex -16.5279 20.3651 0
+    endloop
+  endfacet
+  facet normal 0.743208 -0.669061 0
+    outer loop
+      vertex -16.5279 20.3651 1
+      vertex -16.2202 20.7069 0
+      vertex -16.2202 20.7069 1
+    endloop
+  endfacet
+  facet normal 0.743208 -0.669061 0
+    outer loop
+      vertex -16.2202 20.7069 0
+      vertex -16.5279 20.3651 1
+      vertex -16.5279 20.3651 0
+    endloop
+  endfacet
+  facet normal 0.951069 -0.308978 0
+    outer loop
+      vertex -15.9902 21.1052 1
+      vertex -15.8481 21.5426 0
+      vertex -15.8481 21.5426 1
+    endloop
+  endfacet
+  facet normal 0.951069 -0.308978 0
+    outer loop
+      vertex -15.8481 21.5426 0
+      vertex -15.9902 21.1052 1
+      vertex -15.9902 21.1052 0
+    endloop
+  endfacet
+  facet normal -0.587861 -0.808962 0
+    outer loop
+      vertex -19.4721 20.3651 0
+      vertex -19.1 20.0947 1
+      vertex -19.4721 20.3651 1
+    endloop
+  endfacet
+  facet normal -0.587861 -0.808962 -0
+    outer loop
+      vertex -19.1 20.0947 1
+      vertex -19.4721 20.3651 0
+      vertex -19.1 20.0947 0
+    endloop
+  endfacet
+  facet normal -0.865986 -0.500067 0
+    outer loop
+      vertex -19.7798 20.7069 0
+      vertex -20.0098 21.1052 1
+      vertex -20.0098 21.1052 0
+    endloop
+  endfacet
+  facet normal -0.865986 -0.500067 0
+    outer loop
+      vertex -20.0098 21.1052 1
+      vertex -19.7798 20.7069 0
+      vertex -19.7798 20.7069 1
+    endloop
+  endfacet
+  facet normal -0.743208 -0.669061 0
+    outer loop
+      vertex -19.4721 20.3651 0
+      vertex -19.7798 20.7069 1
+      vertex -19.7798 20.7069 0
+    endloop
+  endfacet
+  facet normal -0.743208 -0.669061 0
+    outer loop
+      vertex -19.7798 20.7069 1
+      vertex -19.4721 20.3651 0
+      vertex -19.4721 20.3651 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex -17.3202 19.9077 0
+      vertex -16.9 20.0947 1
+      vertex -17.3202 19.9077 1
+    endloop
+  endfacet
+  facet normal 0.406582 -0.913614 0
+    outer loop
+      vertex -16.9 20.0947 1
+      vertex -17.3202 19.9077 0
+      vertex -16.9 20.0947 0
+    endloop
+  endfacet
+  facet normal -0.207895 -0.978151 0
+    outer loop
+      vertex -18.6798 19.9077 0
+      vertex -18.23 19.8121 1
+      vertex -18.6798 19.9077 1
+    endloop
+  endfacet
+  facet normal -0.207895 -0.978151 -0
+    outer loop
+      vertex -18.23 19.8121 1
+      vertex -18.6798 19.9077 0
+      vertex -18.23 19.8121 0
+    endloop
+  endfacet
+  facet normal -0.951069 -0.308978 0
+    outer loop
+      vertex -20.0098 21.1052 0
+      vertex -20.1519 21.5426 1
+      vertex -20.1519 21.5426 0
+    endloop
+  endfacet
+  facet normal -0.951069 -0.308978 0
+    outer loop
+      vertex -20.1519 21.5426 1
+      vertex -20.0098 21.1052 0
+      vertex -20.0098 21.1052 1
+    endloop
+  endfacet
+  facet normal -0.994516 -0.104583 0
+    outer loop
+      vertex -20.1519 21.5426 0
+      vertex -20.2 22 1
+      vertex -20.2 22 0
+    endloop
+  endfacet
+  facet normal -0.994516 -0.104583 0
+    outer loop
+      vertex -20.2 22 1
+      vertex -20.1519 21.5426 0
+      vertex -20.1519 21.5426 1
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 0
+    outer loop
+      vertex -19.1 20.0947 0
+      vertex -18.6798 19.9077 1
+      vertex -19.1 20.0947 1
+    endloop
+  endfacet
+  facet normal -0.406582 -0.913614 -0
+    outer loop
+      vertex -18.6798 19.9077 1
+      vertex -19.1 20.0947 0
+      vertex -18.6798 19.9077 0
+    endloop
+  endfacet
+  facet normal -0.994498 -0.104759 0
+    outer loop
+      vertex -17 22 0
+      vertex -17.0219 22.2079 1
+      vertex -17.0219 22.2079 0
+    endloop
+  endfacet
+  facet normal -0.994498 -0.104759 0
+    outer loop
+      vertex -17.0219 22.2079 1
+      vertex -17 22 0
+      vertex -17 22 1
+    endloop
+  endfacet
+  facet normal 0.994498 -0.104759 0
+    outer loop
+      vertex -19 22 1
+      vertex -18.9781 22.2079 0
+      vertex -18.9781 22.2079 1
+    endloop
+  endfacet
+  facet normal 0.994498 -0.104759 0
+    outer loop
+      vertex -18.9781 22.2079 0
+      vertex -19 22 1
+      vertex -19 22 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -18.1045 22.9945 0
+      vertex -17.8955 22.9945 1
+      vertex -18.1045 22.9945 1
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -17.8955 22.9945 1
+      vertex -18.1045 22.9945 0
+      vertex -17.8955 22.9945 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.8955 21.0055 0
+      vertex -18.1045 21.0055 1
+      vertex -17.8955 21.0055 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.1045 21.0055 1
+      vertex -17.8955 21.0055 0
+      vertex -18.1045 21.0055 0
+    endloop
+  endfacet
+  facet normal -0.587916 -0.808922 0
+    outer loop
+      vertex -17.5 22.866 0
+      vertex -17.3309 22.7431 1
+      vertex -17.5 22.866 1
+    endloop
+  endfacet
+  facet normal -0.587916 -0.808922 -0
+    outer loop
+      vertex -17.3309 22.7431 1
+      vertex -17.5 22.866 0
+      vertex -17.3309 22.7431 0
+    endloop
+  endfacet
+  facet normal -0.406981 -0.913436 0
+    outer loop
+      vertex -17.691 22.9511 0
+      vertex -17.5 22.866 1
+      vertex -17.691 22.9511 1
+    endloop
+  endfacet
+  facet normal -0.406981 -0.913436 -0
+    outer loop
+      vertex -17.5 22.866 1
+      vertex -17.691 22.9511 0
+      vertex -17.5 22.866 0
+    endloop
+  endfacet
+  facet normal 0.587916 -0.808922 0
+    outer loop
+      vertex -18.6691 22.7431 0
+      vertex -18.5 22.866 1
+      vertex -18.6691 22.7431 1
+    endloop
+  endfacet
+  facet normal 0.587916 -0.808922 0
+    outer loop
+      vertex -18.5 22.866 1
+      vertex -18.6691 22.7431 0
+      vertex -18.5 22.866 0
+    endloop
+  endfacet
+  facet normal 0.207601 -0.978214 0
+    outer loop
+      vertex -18.309 22.9511 0
+      vertex -18.1045 22.9945 1
+      vertex -18.309 22.9511 1
+    endloop
+  endfacet
+  facet normal 0.207601 -0.978214 0
+    outer loop
+      vertex -18.1045 22.9945 1
+      vertex -18.309 22.9511 0
+      vertex -18.1045 22.9945 0
+    endloop
+  endfacet
+  facet normal -0.866146 -0.499791 0
+    outer loop
+      vertex -17.0865 22.4067 0
+      vertex -17.191 22.5878 1
+      vertex -17.191 22.5878 0
+    endloop
+  endfacet
+  facet normal -0.866146 -0.499791 0
+    outer loop
+      vertex -17.191 22.5878 1
+      vertex -17.0865 22.4067 0
+      vertex -17.0865 22.4067 1
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309043 0
+    outer loop
+      vertex -17.0219 22.2079 0
+      vertex -17.0865 22.4067 1
+      vertex -17.0865 22.4067 0
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309043 0
+    outer loop
+      vertex -17.0865 22.4067 1
+      vertex -17.0219 22.2079 0
+      vertex -17.0219 22.2079 1
+    endloop
+  endfacet
+  facet normal -0.742985 -0.669308 0
+    outer loop
+      vertex -17.191 22.5878 0
+      vertex -17.3309 22.7431 1
+      vertex -17.3309 22.7431 0
+    endloop
+  endfacet
+  facet normal -0.742985 -0.669308 0
+    outer loop
+      vertex -17.3309 22.7431 1
+      vertex -17.191 22.5878 0
+      vertex -17.191 22.5878 1
+    endloop
+  endfacet
+  facet normal -0.207601 -0.978214 0
+    outer loop
+      vertex -17.8955 22.9945 0
+      vertex -17.691 22.9511 1
+      vertex -17.8955 22.9945 1
+    endloop
+  endfacet
+  facet normal -0.207601 -0.978214 -0
+    outer loop
+      vertex -17.691 22.9511 1
+      vertex -17.8955 22.9945 0
+      vertex -17.691 22.9511 0
+    endloop
+  endfacet
+  facet normal 0.866146 -0.499791 0
+    outer loop
+      vertex -18.9135 22.4067 1
+      vertex -18.809 22.5878 0
+      vertex -18.809 22.5878 1
+    endloop
+  endfacet
+  facet normal 0.866146 -0.499791 0
+    outer loop
+      vertex -18.809 22.5878 0
+      vertex -18.9135 22.4067 1
+      vertex -18.9135 22.4067 0
+    endloop
+  endfacet
+  facet normal 0.742985 -0.669308 0
+    outer loop
+      vertex -18.809 22.5878 1
+      vertex -18.6691 22.7431 0
+      vertex -18.6691 22.7431 1
+    endloop
+  endfacet
+  facet normal 0.742985 -0.669308 0
+    outer loop
+      vertex -18.6691 22.7431 0
+      vertex -18.809 22.5878 1
+      vertex -18.809 22.5878 0
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309043 0
+    outer loop
+      vertex -18.9781 22.2079 1
+      vertex -18.9135 22.4067 0
+      vertex -18.9135 22.4067 1
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309043 0
+    outer loop
+      vertex -18.9135 22.4067 0
+      vertex -18.9781 22.2079 1
+      vertex -18.9781 22.2079 0
+    endloop
+  endfacet
+  facet normal 0.406981 -0.913436 0
+    outer loop
+      vertex -18.5 22.866 0
+      vertex -18.309 22.9511 1
+      vertex -18.5 22.866 1
+    endloop
+  endfacet
+  facet normal 0.406981 -0.913436 0
+    outer loop
+      vertex -18.309 22.9511 1
+      vertex -18.5 22.866 0
+      vertex -18.309 22.9511 0
+    endloop
+  endfacet
+  facet normal -0.994498 0.104759 0
+    outer loop
+      vertex -17.0219 21.7921 0
+      vertex -17 22 1
+      vertex -17 22 0
+    endloop
+  endfacet
+  facet normal -0.994498 0.104759 0
+    outer loop
+      vertex -17 22 1
+      vertex -17.0219 21.7921 0
+      vertex -17.0219 21.7921 1
+    endloop
+  endfacet
+  facet normal -0.207601 0.978214 0
+    outer loop
+      vertex -17.691 21.0489 0
+      vertex -17.8955 21.0055 1
+      vertex -17.691 21.0489 1
+    endloop
+  endfacet
+  facet normal -0.207601 0.978214 0
+    outer loop
+      vertex -17.8955 21.0055 1
+      vertex -17.691 21.0489 0
+      vertex -17.8955 21.0055 0
+    endloop
+  endfacet
+  facet normal -0.742985 0.669308 0
+    outer loop
+      vertex -17.3309 21.2569 0
+      vertex -17.191 21.4122 1
+      vertex -17.191 21.4122 0
+    endloop
+  endfacet
+  facet normal -0.742985 0.669308 0
+    outer loop
+      vertex -17.191 21.4122 1
+      vertex -17.3309 21.2569 0
+      vertex -17.3309 21.2569 1
+    endloop
+  endfacet
+  facet normal -0.951048 0.309043 0
+    outer loop
+      vertex -17.0865 21.5933 0
+      vertex -17.0219 21.7921 1
+      vertex -17.0219 21.7921 0
+    endloop
+  endfacet
+  facet normal -0.951048 0.309043 0
+    outer loop
+      vertex -17.0219 21.7921 1
+      vertex -17.0865 21.5933 0
+      vertex -17.0865 21.5933 1
+    endloop
+  endfacet
+  facet normal -0.866146 0.499791 0
+    outer loop
+      vertex -17.191 21.4122 0
+      vertex -17.0865 21.5933 1
+      vertex -17.0865 21.5933 0
+    endloop
+  endfacet
+  facet normal -0.866146 0.499791 0
+    outer loop
+      vertex -17.0865 21.5933 1
+      vertex -17.191 21.4122 0
+      vertex -17.191 21.4122 1
+    endloop
+  endfacet
+  facet normal 0.406981 0.913436 -0
+    outer loop
+      vertex -18.309 21.0489 0
+      vertex -18.5 21.134 1
+      vertex -18.309 21.0489 1
+    endloop
+  endfacet
+  facet normal 0.406981 0.913436 0
+    outer loop
+      vertex -18.5 21.134 1
+      vertex -18.309 21.0489 0
+      vertex -18.5 21.134 0
+    endloop
+  endfacet
+  facet normal 0.866146 0.499791 0
+    outer loop
+      vertex -18.809 21.4122 1
+      vertex -18.9135 21.5933 0
+      vertex -18.9135 21.5933 1
+    endloop
+  endfacet
+  facet normal 0.866146 0.499791 0
+    outer loop
+      vertex -18.9135 21.5933 0
+      vertex -18.809 21.4122 1
+      vertex -18.809 21.4122 0
+    endloop
+  endfacet
+  facet normal -0.587916 0.808922 0
+    outer loop
+      vertex -17.3309 21.2569 0
+      vertex -17.5 21.134 1
+      vertex -17.3309 21.2569 1
+    endloop
+  endfacet
+  facet normal -0.587916 0.808922 0
+    outer loop
+      vertex -17.5 21.134 1
+      vertex -17.3309 21.2569 0
+      vertex -17.5 21.134 0
+    endloop
+  endfacet
+  facet normal -0.406981 0.913436 0
+    outer loop
+      vertex -17.5 21.134 0
+      vertex -17.691 21.0489 1
+      vertex -17.5 21.134 1
+    endloop
+  endfacet
+  facet normal -0.406981 0.913436 0
+    outer loop
+      vertex -17.691 21.0489 1
+      vertex -17.5 21.134 0
+      vertex -17.691 21.0489 0
+    endloop
+  endfacet
+  facet normal 0.207601 0.978214 -0
+    outer loop
+      vertex -18.1045 21.0055 0
+      vertex -18.309 21.0489 1
+      vertex -18.1045 21.0055 1
+    endloop
+  endfacet
+  facet normal 0.207601 0.978214 0
+    outer loop
+      vertex -18.309 21.0489 1
+      vertex -18.1045 21.0055 0
+      vertex -18.309 21.0489 0
+    endloop
+  endfacet
+  facet normal 0.587916 0.808922 -0
+    outer loop
+      vertex -18.5 21.134 0
+      vertex -18.6691 21.2569 1
+      vertex -18.5 21.134 1
+    endloop
+  endfacet
+  facet normal 0.587916 0.808922 0
+    outer loop
+      vertex -18.6691 21.2569 1
+      vertex -18.5 21.134 0
+      vertex -18.6691 21.2569 0
+    endloop
+  endfacet
+  facet normal 0.742985 0.669308 0
+    outer loop
+      vertex -18.6691 21.2569 1
+      vertex -18.809 21.4122 0
+      vertex -18.809 21.4122 1
+    endloop
+  endfacet
+  facet normal 0.742985 0.669308 0
+    outer loop
+      vertex -18.809 21.4122 0
+      vertex -18.6691 21.2569 1
+      vertex -18.6691 21.2569 0
+    endloop
+  endfacet
+  facet normal 0.951048 0.309043 0
+    outer loop
+      vertex -18.9135 21.5933 1
+      vertex -18.9781 21.7921 0
+      vertex -18.9781 21.7921 1
+    endloop
+  endfacet
+  facet normal 0.951048 0.309043 0
+    outer loop
+      vertex -18.9781 21.7921 0
+      vertex -18.9135 21.5933 1
+      vertex -18.9135 21.5933 0
+    endloop
+  endfacet
+  facet normal 0.994498 0.104759 0
+    outer loop
+      vertex -18.9781 21.7921 1
+      vertex -19 22 0
+      vertex -19 22 1
+    endloop
+  endfacet
+  facet normal 0.994498 0.104759 0
+    outer loop
+      vertex -19 22 0
+      vertex -18.9781 21.7921 1
+      vertex -18.9781 21.7921 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
2ピンのアウトレットにjst-phを接続した状態で使えるケースを作成しました。
3Dプリンタによっては精度が甘く嵌まらない場合もあるので、その際はケーブルタイで留めることができます。

![20200227_235146](https://user-images.githubusercontent.com/1223433/75622444-a3153000-5be3-11ea-9699-4364c118c7b0.jpg)

![20200227_235131](https://user-images.githubusercontent.com/1223433/75622443-a0b2d600-5be3-11ea-8fba-f03588284a5e.jpg)

![20200228_230614](https://user-images.githubusercontent.com/1223433/75622439-9abcf500-5be3-11ea-894e-9f1706e9ab2b.jpg)
